### PR TITLE
chore: fix .gitignore for IntelliJ and Maven

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 ### IntelliJ IDEA ###
+.idea/
+*.iml
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/
@@ -25,6 +27,9 @@ bin/
 
 ### VS Code ###
 .vscode/
+
+### Maven ###
+target/
 
 ### Mac OS ###
 .DS_Store


### PR DESCRIPTION
## Summary
- Add `.idea/` and `*.iml` to exclude IntelliJ project files
- Add `target/` to exclude Maven build output