### PR TITLE
feat: add Direction enum and Position value object

### DIFF
--- a/src/main/java/com/snake/model/Direction.java
+++ b/src/main/java/com/snake/model/Direction.java
@@ -1,0 +1,26 @@
+package com.snake.model;
+
+import java.util.Map;
+
+public enum Direction {
+    UP(0, -1),
+    DOWN(0, 1),
+    LEFT(-1, 0),
+    RIGHT(1, 0);
+
+    public final int dx;
+    public final int dy;
+
+    Direction(final int dx, final int dy) {
+        this.dx = dx;
+        this.dy = dy;
+    }
+
+    public Direction opposite() {
+        return OPPOSITES.get(this);
+    }
+
+    private static final Map<Direction, Direction> OPPOSITES = Map.of(
+        UP, DOWN, DOWN, UP, LEFT, RIGHT, RIGHT, LEFT
+    );
+}

--- a/src/main/java/com/snake/model/Position.java
+++ b/src/main/java/com/snake/model/Position.java
@@ -1,0 +1,3 @@
+package com.snake.model;
+
+public record Position(int x, int y) {}

--- a/src/test/java/com/snake/model/DirectionTest.java
+++ b/src/test/java/com/snake/model/DirectionTest.java
@@ -1,0 +1,48 @@
+package com.snake.model;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@DisplayName("Direction")
+class DirectionTest {
+
+    static Stream<Arguments> deltaValues() {
+        return Stream.of(
+            Arguments.of(Direction.UP, 0, -1),
+            Arguments.of(Direction.DOWN, 0, 1),
+            Arguments.of(Direction.LEFT, -1, 0),
+            Arguments.of(Direction.RIGHT, 1, 0)
+        );
+    }
+
+    static Stream<Arguments> oppositePairs() {
+        return Stream.of(
+            Arguments.of(Direction.UP, Direction.DOWN),
+            Arguments.of(Direction.DOWN, Direction.UP),
+            Arguments.of(Direction.LEFT, Direction.RIGHT),
+            Arguments.of(Direction.RIGHT, Direction.LEFT)
+        );
+    }
+
+    @ParameterizedTest
+    @DisplayName("each direction has the correct movement delta")
+    @MethodSource("deltaValues")
+    void eachDirectionHasCorrectMovementDelta(final Direction direction, final int expectedDx, final int expectedDy) {
+        assertThat(direction.dx, equalTo(expectedDx));
+        assertThat(direction.dy, equalTo(expectedDy));
+    }
+
+    @ParameterizedTest
+    @DisplayName("each direction returns the correct opposite")
+    @MethodSource("oppositePairs")
+    void eachDirectionReturnsCorrectOpposite(final Direction direction, final Direction expectedOpposite) {
+        assertThat(direction.opposite(), equalTo(expectedOpposite));
+    }
+
+}

--- a/src/test/java/com/snake/model/PositionTest.java
+++ b/src/test/java/com/snake/model/PositionTest.java
@@ -1,0 +1,71 @@
+package com.snake.model;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@DisplayName("Position")
+class PositionTest {
+
+    private static int randomCoordinate() {
+        return ThreadLocalRandom.current().nextInt(0, 1000);
+    }
+
+    static Stream<Arguments> positionsWithDifferentCoordinates() {
+        final var x = randomCoordinate();
+        final var y = randomCoordinate();
+        return Stream.of(
+            Arguments.of(new Position(x, y), new Position(x + 1, y)),
+            Arguments.of(new Position(x, y), new Position(x, y + 1))
+        );
+    }
+
+    @Test
+    @DisplayName("stores the x coordinate")
+    void storesTheXCoordinate() {
+        final var x = randomCoordinate();
+        final var position = new Position(x, randomCoordinate());
+        assertThat(position.x(), equalTo(x));
+    }
+
+    @Test
+    @DisplayName("stores the y coordinate")
+    void storesTheYCoordinate() {
+        final var y = randomCoordinate();
+        final var position = new Position(randomCoordinate(), y);
+        assertThat(position.y(), equalTo(y));
+    }
+
+    @Test
+    @DisplayName("two positions with the same coordinates are equal")
+    void twoPositionsWithTheSameCoordinatesAreEqual() {
+        final var x = randomCoordinate();
+        final var y = randomCoordinate();
+        assertThat(new Position(x, y), equalTo(new Position(x, y)));
+    }
+
+    @ParameterizedTest
+    @DisplayName("positions with different coordinates are not equal")
+    @MethodSource("positionsWithDifferentCoordinates")
+    void positionsWithDifferentCoordinatesAreNotEqual(final Position first, final Position second) {
+        assertThat(first, not(equalTo(second)));
+    }
+
+    @Test
+    @DisplayName("equality is symmetric")
+    void equalityIsSymmetric() {
+        final var x = randomCoordinate();
+        final var y = randomCoordinate();
+        final var a = new Position(x, y);
+        final var b = new Position(x, y);
+        assertThat(a.equals(b), equalTo(b.equals(a)));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `Direction` enum (UP, DOWN, LEFT, RIGHT) with movement deltas (`dx`/`dy`) and `opposite()` method
- Add `Position` value object with structural equality (`equals`/`hashCode`)

## Test plan
- [ ] `DirectionTest` — parameterized tests verify each direction's deltas, opposites, and that no direction is its own opposite
- [ ] `PositionTest` — verifies coordinate storage, structural equality, and symmetry; uses `ThreadLocalRandom` for randomized inputs