### PR TITLE
feat: add Snake (Tasks 3–6)

### DIFF
--- a/src/main/java/com/snake/model/Snake.java
+++ b/src/main/java/com/snake/model/Snake.java
@@ -1,0 +1,56 @@
+package com.snake.model;
+
+import java.util.ArrayDeque;
+
+public class Snake {
+
+    private final ArrayDeque<Position> body;
+    private Direction direction;
+    private int pendingGrowth;
+
+    public Snake(final Position start, final Direction direction) {
+        this.body = new ArrayDeque<>();
+        this.body.addFirst(start);
+        this.direction = direction;
+        this.pendingGrowth = 0;
+    }
+
+    public void move() {
+        final var newHead = new Position(
+            body.getFirst().x() + direction.dx,
+            body.getFirst().y() + direction.dy
+        );
+        body.addFirst(newHead);
+        if (pendingGrowth > 0) {
+            pendingGrowth--;
+        } else {
+            body.removeLast();
+        }
+    }
+
+    public void grow() {
+        pendingGrowth++;
+    }
+
+    public void changeDirection(final Direction newDirection) {
+        if (!newDirection.equals(direction.opposite())) {
+            direction = newDirection;
+        }
+    }
+
+    public Position head() {
+        return body.getFirst();
+    }
+
+    public ArrayDeque<Position> body() {
+        return body;
+    }
+
+    public Direction direction() {
+        return direction;
+    }
+
+    public int size() {
+        return body.size();
+    }
+}

--- a/src/test/java/com/snake/model/PositionTest.java
+++ b/src/test/java/com/snake/model/PositionTest.java
@@ -4,6 +4,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 
+import static com.snake.model.TestData.randomCoordinate;
+
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,8 +17,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 class PositionTest {
 
     static Stream<Arguments> positionsWithDifferentCoordinates() {
-        final var x = TestData.randomCoordinate();
-        final var y = TestData.randomCoordinate();
+        final var x = randomCoordinate();
+        final var y = randomCoordinate();
         return Stream.of(
             Arguments.of(new Position(x, y), new Position(x + 1, y)),
             Arguments.of(new Position(x, y), new Position(x, y + 1))
@@ -26,24 +28,24 @@ class PositionTest {
     @Test
     @DisplayName("stores the x coordinate")
     void storesTheXCoordinate() {
-        final var x = TestData.randomCoordinate();
-        final var position = new Position(x, TestData.randomCoordinate());
+        final var x = randomCoordinate();
+        final var position = new Position(x, randomCoordinate());
         assertThat(position.x(), equalTo(x));
     }
 
     @Test
     @DisplayName("stores the y coordinate")
     void storesTheYCoordinate() {
-        final var y = TestData.randomCoordinate();
-        final var position = new Position(TestData.randomCoordinate(), y);
+        final var y = randomCoordinate();
+        final var position = new Position(randomCoordinate(), y);
         assertThat(position.y(), equalTo(y));
     }
 
     @Test
     @DisplayName("two positions with the same coordinates are equal")
     void twoPositionsWithTheSameCoordinatesAreEqual() {
-        final var x = TestData.randomCoordinate();
-        final var y = TestData.randomCoordinate();
+        final var x = randomCoordinate();
+        final var y = randomCoordinate();
         assertThat(new Position(x, y), equalTo(new Position(x, y)));
     }
 
@@ -57,8 +59,8 @@ class PositionTest {
     @Test
     @DisplayName("equality is symmetric")
     void equalityIsSymmetric() {
-        final var x = TestData.randomCoordinate();
-        final var y = TestData.randomCoordinate();
+        final var x = randomCoordinate();
+        final var y = randomCoordinate();
         final var a = new Position(x, y);
         final var b = new Position(x, y);
         assertThat(a.equals(b), equalTo(b.equals(a)));

--- a/src/test/java/com/snake/model/PositionTest.java
+++ b/src/test/java/com/snake/model/PositionTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,13 +14,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 @DisplayName("Position")
 class PositionTest {
 
-    private static int randomCoordinate() {
-        return ThreadLocalRandom.current().nextInt(0, 1000);
-    }
-
     static Stream<Arguments> positionsWithDifferentCoordinates() {
-        final var x = randomCoordinate();
-        final var y = randomCoordinate();
+        final var x = TestData.randomCoordinate();
+        final var y = TestData.randomCoordinate();
         return Stream.of(
             Arguments.of(new Position(x, y), new Position(x + 1, y)),
             Arguments.of(new Position(x, y), new Position(x, y + 1))
@@ -31,24 +26,24 @@ class PositionTest {
     @Test
     @DisplayName("stores the x coordinate")
     void storesTheXCoordinate() {
-        final var x = randomCoordinate();
-        final var position = new Position(x, randomCoordinate());
+        final var x = TestData.randomCoordinate();
+        final var position = new Position(x, TestData.randomCoordinate());
         assertThat(position.x(), equalTo(x));
     }
 
     @Test
     @DisplayName("stores the y coordinate")
     void storesTheYCoordinate() {
-        final var y = randomCoordinate();
-        final var position = new Position(randomCoordinate(), y);
+        final var y = TestData.randomCoordinate();
+        final var position = new Position(TestData.randomCoordinate(), y);
         assertThat(position.y(), equalTo(y));
     }
 
     @Test
     @DisplayName("two positions with the same coordinates are equal")
     void twoPositionsWithTheSameCoordinatesAreEqual() {
-        final var x = randomCoordinate();
-        final var y = randomCoordinate();
+        final var x = TestData.randomCoordinate();
+        final var y = TestData.randomCoordinate();
         assertThat(new Position(x, y), equalTo(new Position(x, y)));
     }
 
@@ -62,8 +57,8 @@ class PositionTest {
     @Test
     @DisplayName("equality is symmetric")
     void equalityIsSymmetric() {
-        final var x = randomCoordinate();
-        final var y = randomCoordinate();
+        final var x = TestData.randomCoordinate();
+        final var y = TestData.randomCoordinate();
         final var a = new Position(x, y);
         final var b = new Position(x, y);
         assertThat(a.equals(b), equalTo(b.equals(a)));

--- a/src/test/java/com/snake/model/SnakeTest.java
+++ b/src/test/java/com/snake/model/SnakeTest.java
@@ -5,6 +5,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 
+import static com.snake.model.TestData.randomPosition;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -14,14 +16,14 @@ class SnakeTest {
     @Test
     @DisplayName("starts with size 1")
     void startsWithSizeOne() {
-        final var snake = new Snake(TestData.randomPosition(), Direction.RIGHT);
+        final var snake = new Snake(randomPosition(), Direction.RIGHT);
         assertThat(snake.size(), equalTo(1));
     }
 
     @Test
     @DisplayName("head is at the starting position")
     void headIsAtStartingPosition() {
-        final var start = TestData.randomPosition();
+        final var start = randomPosition();
         final var snake = new Snake(start, Direction.RIGHT);
         assertThat(snake.head(), equalTo(start));
     }
@@ -29,14 +31,14 @@ class SnakeTest {
     @Test
     @DisplayName("reports the correct initial direction")
     void reportsCorrectInitialDirection() {
-        final var snake = new Snake(TestData.randomPosition(), Direction.UP);
+        final var snake = new Snake(randomPosition(), Direction.UP);
         assertThat(snake.direction(), equalTo(Direction.UP));
     }
 
     @Test
     @DisplayName("head moves one step in current direction after move")
     void headMovesOneStepInCurrentDirection() {
-        final var start = TestData.randomPosition();
+        final var start = randomPosition();
         final var snake = new Snake(start, Direction.RIGHT);
         snake.move();
         assertThat(snake.head(), equalTo(new Position(start.x() + 1, start.y())));
@@ -45,7 +47,7 @@ class SnakeTest {
     @Test
     @DisplayName("old tail is removed after move")
     void oldTailIsRemovedAfterMove() {
-        final var start = TestData.randomPosition();
+        final var start = randomPosition();
         final var snake = new Snake(start, Direction.RIGHT);
         snake.move();
         assertThat(snake.body(), not(hasItem(start)));
@@ -54,7 +56,7 @@ class SnakeTest {
     @Test
     @DisplayName("size is unchanged after move")
     void sizeIsUnchangedAfterMove() {
-        final var snake = new Snake(TestData.randomPosition(), Direction.DOWN);
+        final var snake = new Snake(randomPosition(), Direction.DOWN);
         snake.move();
         assertThat(snake.size(), equalTo(1));
     }
@@ -62,7 +64,7 @@ class SnakeTest {
     @Test
     @DisplayName("size increases by 1 after grow then move")
     void sizeIncreasesByOneAfterGrowThenMove() {
-        final var snake = new Snake(TestData.randomPosition(), Direction.RIGHT);
+        final var snake = new Snake(randomPosition(), Direction.RIGHT);
         snake.grow();
         snake.move();
         assertThat(snake.size(), equalTo(2));
@@ -71,7 +73,7 @@ class SnakeTest {
     @Test
     @DisplayName("each grow call adds exactly one segment on the next move")
     void eachGrowCallAddsExactlyOneSegment() {
-        final var snake = new Snake(TestData.randomPosition(), Direction.RIGHT);
+        final var snake = new Snake(randomPosition(), Direction.RIGHT);
         snake.grow();
         snake.grow();
         snake.move();
@@ -83,7 +85,7 @@ class SnakeTest {
     @Test
     @DisplayName("body segments are in correct spatial order after growth")
     void bodySegmentsAreInCorrectSpatialOrderAfterGrowth() {
-        final var start = TestData.randomPosition();
+        final var start = randomPosition();
         final var snake = new Snake(start, Direction.RIGHT);
         snake.grow();
         snake.move();
@@ -94,7 +96,7 @@ class SnakeTest {
     @Test
     @DisplayName("adopts new direction when change is valid")
     void adoptsNewDirectionWhenValid() {
-        final var snake = new Snake(TestData.randomPosition(), Direction.RIGHT);
+        final var snake = new Snake(randomPosition(), Direction.RIGHT);
         snake.changeDirection(Direction.UP);
         assertThat(snake.direction(), equalTo(Direction.UP));
     }
@@ -102,7 +104,7 @@ class SnakeTest {
     @Test
     @DisplayName("ignores direction change that would reverse into itself")
     void ignoresReversalDirectionChange() {
-        final var snake = new Snake(TestData.randomPosition(), Direction.RIGHT);
+        final var snake = new Snake(randomPosition(), Direction.RIGHT);
         snake.changeDirection(Direction.LEFT);
         assertThat(snake.direction(), equalTo(Direction.RIGHT));
     }
@@ -110,7 +112,7 @@ class SnakeTest {
     @Test
     @DisplayName("direction is unchanged after an ignored input")
     void directionUnchangedAfterIgnoredInput() {
-        final var snake = new Snake(TestData.randomPosition(), Direction.UP);
+        final var snake = new Snake(randomPosition(), Direction.UP);
         snake.changeDirection(Direction.DOWN);
         assertThat(snake.direction(), equalTo(Direction.UP));
     }

--- a/src/test/java/com/snake/model/SnakeTest.java
+++ b/src/test/java/com/snake/model/SnakeTest.java
@@ -1,0 +1,125 @@
+package com.snake.model;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+
+import java.util.concurrent.ThreadLocalRandom;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Snake")
+class SnakeTest {
+
+    private static Position randomPosition() {
+        return new Position(
+            ThreadLocalRandom.current().nextInt(1, 100),
+            ThreadLocalRandom.current().nextInt(1, 100)
+        );
+    }
+
+    @Test
+    @DisplayName("starts with size 1")
+    void startsWithSizeOne() {
+        final var snake = new Snake(randomPosition(), Direction.RIGHT);
+        assertThat(snake.size(), equalTo(1));
+    }
+
+    @Test
+    @DisplayName("head is at the starting position")
+    void headIsAtStartingPosition() {
+        final var start = randomPosition();
+        final var snake = new Snake(start, Direction.RIGHT);
+        assertThat(snake.head(), equalTo(start));
+    }
+
+    @Test
+    @DisplayName("reports the correct initial direction")
+    void reportsCorrectInitialDirection() {
+        final var snake = new Snake(randomPosition(), Direction.UP);
+        assertThat(snake.direction(), equalTo(Direction.UP));
+    }
+
+    @Test
+    @DisplayName("head moves one step in current direction after move")
+    void headMovesOneStepInCurrentDirection() {
+        final var start = randomPosition();
+        final var snake = new Snake(start, Direction.RIGHT);
+        snake.move();
+        assertThat(snake.head(), equalTo(new Position(start.x() + 1, start.y())));
+    }
+
+    @Test
+    @DisplayName("old tail is removed after move")
+    void oldTailIsRemovedAfterMove() {
+        final var start = randomPosition();
+        final var snake = new Snake(start, Direction.RIGHT);
+        snake.move();
+        assertThat(snake.body(), not(hasItem(start)));
+    }
+
+    @Test
+    @DisplayName("size is unchanged after move")
+    void sizeIsUnchangedAfterMove() {
+        final var snake = new Snake(randomPosition(), Direction.DOWN);
+        snake.move();
+        assertThat(snake.size(), equalTo(1));
+    }
+
+    @Test
+    @DisplayName("size increases by 1 after grow then move")
+    void sizeIncreasesByOneAfterGrowThenMove() {
+        final var snake = new Snake(randomPosition(), Direction.RIGHT);
+        snake.grow();
+        snake.move();
+        assertThat(snake.size(), equalTo(2));
+    }
+
+    @Test
+    @DisplayName("each grow call adds exactly one segment on the next move")
+    void eachGrowCallAddsExactlyOneSegment() {
+        final var snake = new Snake(randomPosition(), Direction.RIGHT);
+        snake.grow();
+        snake.grow();
+        snake.move();
+        assertThat(snake.size(), equalTo(2));
+        snake.move();
+        assertThat(snake.size(), equalTo(3));
+    }
+
+    @Test
+    @DisplayName("body segments are in correct spatial order after growth")
+    void bodySegmentsAreInCorrectSpatialOrderAfterGrowth() {
+        final var start = randomPosition();
+        final var snake = new Snake(start, Direction.RIGHT);
+        snake.grow();
+        snake.move();
+        assertThat(snake.head(), equalTo(new Position(start.x() + 1, start.y())));
+        assertThat(snake.body().getLast(), equalTo(start));
+    }
+
+    @Test
+    @DisplayName("adopts new direction when change is valid")
+    void adoptsNewDirectionWhenValid() {
+        final var snake = new Snake(randomPosition(), Direction.RIGHT);
+        snake.changeDirection(Direction.UP);
+        assertThat(snake.direction(), equalTo(Direction.UP));
+    }
+
+    @Test
+    @DisplayName("ignores direction change that would reverse into itself")
+    void ignoresReversalDirectionChange() {
+        final var snake = new Snake(randomPosition(), Direction.RIGHT);
+        snake.changeDirection(Direction.LEFT);
+        assertThat(snake.direction(), equalTo(Direction.RIGHT));
+    }
+
+    @Test
+    @DisplayName("direction is unchanged after an ignored input")
+    void directionUnchangedAfterIgnoredInput() {
+        final var snake = new Snake(randomPosition(), Direction.UP);
+        snake.changeDirection(Direction.DOWN);
+        assertThat(snake.direction(), equalTo(Direction.UP));
+    }
+}

--- a/src/test/java/com/snake/model/SnakeTest.java
+++ b/src/test/java/com/snake/model/SnakeTest.java
@@ -5,31 +5,23 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 
-import java.util.concurrent.ThreadLocalRandom;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 @DisplayName("Snake")
 class SnakeTest {
 
-    private static Position randomPosition() {
-        return new Position(
-            ThreadLocalRandom.current().nextInt(1, 100),
-            ThreadLocalRandom.current().nextInt(1, 100)
-        );
-    }
-
     @Test
     @DisplayName("starts with size 1")
     void startsWithSizeOne() {
-        final var snake = new Snake(randomPosition(), Direction.RIGHT);
+        final var snake = new Snake(TestData.randomPosition(), Direction.RIGHT);
         assertThat(snake.size(), equalTo(1));
     }
 
     @Test
     @DisplayName("head is at the starting position")
     void headIsAtStartingPosition() {
-        final var start = randomPosition();
+        final var start = TestData.randomPosition();
         final var snake = new Snake(start, Direction.RIGHT);
         assertThat(snake.head(), equalTo(start));
     }
@@ -37,14 +29,14 @@ class SnakeTest {
     @Test
     @DisplayName("reports the correct initial direction")
     void reportsCorrectInitialDirection() {
-        final var snake = new Snake(randomPosition(), Direction.UP);
+        final var snake = new Snake(TestData.randomPosition(), Direction.UP);
         assertThat(snake.direction(), equalTo(Direction.UP));
     }
 
     @Test
     @DisplayName("head moves one step in current direction after move")
     void headMovesOneStepInCurrentDirection() {
-        final var start = randomPosition();
+        final var start = TestData.randomPosition();
         final var snake = new Snake(start, Direction.RIGHT);
         snake.move();
         assertThat(snake.head(), equalTo(new Position(start.x() + 1, start.y())));
@@ -53,7 +45,7 @@ class SnakeTest {
     @Test
     @DisplayName("old tail is removed after move")
     void oldTailIsRemovedAfterMove() {
-        final var start = randomPosition();
+        final var start = TestData.randomPosition();
         final var snake = new Snake(start, Direction.RIGHT);
         snake.move();
         assertThat(snake.body(), not(hasItem(start)));
@@ -62,7 +54,7 @@ class SnakeTest {
     @Test
     @DisplayName("size is unchanged after move")
     void sizeIsUnchangedAfterMove() {
-        final var snake = new Snake(randomPosition(), Direction.DOWN);
+        final var snake = new Snake(TestData.randomPosition(), Direction.DOWN);
         snake.move();
         assertThat(snake.size(), equalTo(1));
     }
@@ -70,7 +62,7 @@ class SnakeTest {
     @Test
     @DisplayName("size increases by 1 after grow then move")
     void sizeIncreasesByOneAfterGrowThenMove() {
-        final var snake = new Snake(randomPosition(), Direction.RIGHT);
+        final var snake = new Snake(TestData.randomPosition(), Direction.RIGHT);
         snake.grow();
         snake.move();
         assertThat(snake.size(), equalTo(2));
@@ -79,7 +71,7 @@ class SnakeTest {
     @Test
     @DisplayName("each grow call adds exactly one segment on the next move")
     void eachGrowCallAddsExactlyOneSegment() {
-        final var snake = new Snake(randomPosition(), Direction.RIGHT);
+        final var snake = new Snake(TestData.randomPosition(), Direction.RIGHT);
         snake.grow();
         snake.grow();
         snake.move();
@@ -91,7 +83,7 @@ class SnakeTest {
     @Test
     @DisplayName("body segments are in correct spatial order after growth")
     void bodySegmentsAreInCorrectSpatialOrderAfterGrowth() {
-        final var start = randomPosition();
+        final var start = TestData.randomPosition();
         final var snake = new Snake(start, Direction.RIGHT);
         snake.grow();
         snake.move();
@@ -102,7 +94,7 @@ class SnakeTest {
     @Test
     @DisplayName("adopts new direction when change is valid")
     void adoptsNewDirectionWhenValid() {
-        final var snake = new Snake(randomPosition(), Direction.RIGHT);
+        final var snake = new Snake(TestData.randomPosition(), Direction.RIGHT);
         snake.changeDirection(Direction.UP);
         assertThat(snake.direction(), equalTo(Direction.UP));
     }
@@ -110,7 +102,7 @@ class SnakeTest {
     @Test
     @DisplayName("ignores direction change that would reverse into itself")
     void ignoresReversalDirectionChange() {
-        final var snake = new Snake(randomPosition(), Direction.RIGHT);
+        final var snake = new Snake(TestData.randomPosition(), Direction.RIGHT);
         snake.changeDirection(Direction.LEFT);
         assertThat(snake.direction(), equalTo(Direction.RIGHT));
     }
@@ -118,7 +110,7 @@ class SnakeTest {
     @Test
     @DisplayName("direction is unchanged after an ignored input")
     void directionUnchangedAfterIgnoredInput() {
-        final var snake = new Snake(randomPosition(), Direction.UP);
+        final var snake = new Snake(TestData.randomPosition(), Direction.UP);
         snake.changeDirection(Direction.DOWN);
         assertThat(snake.direction(), equalTo(Direction.UP));
     }

--- a/src/test/java/com/snake/model/TestData.java
+++ b/src/test/java/com/snake/model/TestData.java
@@ -2,7 +2,9 @@ package com.snake.model;
 
 import java.util.concurrent.ThreadLocalRandom;
 
-class TestData {
+final class TestData {
+
+    private TestData() {}
 
     static int randomCoordinate() {
         return ThreadLocalRandom.current().nextInt(1, 100);

--- a/src/test/java/com/snake/model/TestData.java
+++ b/src/test/java/com/snake/model/TestData.java
@@ -1,0 +1,14 @@
+package com.snake.model;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+class TestData {
+
+    static int randomCoordinate() {
+        return ThreadLocalRandom.current().nextInt(1, 100);
+    }
+
+    static Position randomPosition() {
+        return new Position(randomCoordinate(), randomCoordinate());
+    }
+}


### PR DESCRIPTION
## Summary
Implements all `Snake` behaviours — initialization, movement, growth, and direction change.

Closes #8, #9, #10, #11

## What's in this PR
- `Snake.java` — body as `ArrayDeque<Position>`, pending growth counter, direction reversal guard
- `SnakeTest.java` — 12 tests covering all four behaviours, randomized inputs via `ThreadLocalRandom`

## Design decisions
- **`ArrayDeque`** — O(1) `addFirst`/`removeLast` for head/tail ops, no Node wrapper per element
- **`pendingGrowth` counter** — `grow()` increments it; each `move()` skips tail removal once per pending count, so back-to-back `grow()` calls work correctly
- **Direction reversal blocked** — `changeDirection` silently ignores any direction equal to `direction.opposite()`

## Review checklist
- [ ] `move()` — understand why `addFirst` / `removeLast`
- [ ] `pendingGrowth` — trace two consecutive `grow()` + `move()` calls
- [ ] `changeDirection` — why check `opposite()` instead of a switch?
- [ ] All 26 tests pass (`mvn test`)