### PR TITLE
feat: add Snake (Tasks 3–6)

### DIFF
--- a/src/main/java/com/snake/model/Snake.java
+++ b/src/main/java/com/snake/model/Snake.java
@@ -17,7 +17,7 @@ public class Snake {
         body.removeLast();
     }
 
-    public void eat(final Direction direction) {
+    public void grow(final Direction direction) {
         body.addFirst(nextHead(direction));
     }
 

--- a/src/main/java/com/snake/model/Snake.java
+++ b/src/main/java/com/snake/model/Snake.java
@@ -1,0 +1,56 @@
+package com.snake.model;
+
+import java.util.ArrayDeque;
+
+public class Snake {
+
+    private final ArrayDeque<Position> body;
+    private Direction direction;
+    private int pendingGrowth;
+
+    public Snake(final Position start, final Direction direction) {
+        this.body = new ArrayDeque<>();
+        this.body.addFirst(start);
+        this.direction = direction;
+        this.pendingGrowth = 0;
+    }
+
+    public void move() {
+        final var newHead = new Position(
+            body.getFirst().x() + direction.dx,
+            body.getFirst().y() + direction.dy
+        );
+        body.addFirst(newHead);
+        if (pendingGrowth > 0) {
+            pendingGrowth--;
+        } else {
+            body.removeLast();
+        }
+    }
+
+    public void grow() {
+        pendingGrowth++;
+    }
+
+    public void changeDirection(final Direction newDirection) {
+        if (!newDirection.equals(direction.opposite())) {
+            direction = newDirection;
+        }
+    }
+
+    public Position head() {
+        return body.getFirst();
+    }
+
+    public ArrayDeque<Position> body() {
+        return body;
+    }
+
+    public Direction direction() {
+        return direction;
+    }
+
+    public int size() {
+        return body.size();
+    }
+}

--- a/src/main/java/com/snake/model/Snake.java
+++ b/src/main/java/com/snake/model/Snake.java
@@ -5,40 +5,26 @@ import java.util.ArrayDeque;
 public class Snake {
 
     private final ArrayDeque<Position> body;
-    private Direction direction;
-    private int segmentsToAdd;
 
-    public Snake(final Position start, final Direction direction) {
+    public Snake(final Position start) {
         this.body = new ArrayDeque<>();
         this.body.addFirst(start);
-        this.direction = direction;
-        this.segmentsToAdd = 0;
     }
 
-    public void move() {
-        body.addFirst(nextHead());
-        if (segmentsToAdd > 0) {
-            segmentsToAdd--;
-        } else {
-            body.removeLast();
-        }
+    public void move(final Direction direction) {
+        body.addFirst(nextHead(direction));
+        body.removeLast();
     }
 
-    public void grow() {
-        segmentsToAdd++;
+    public void eat(final Direction direction) {
+        body.addFirst(nextHead(direction));
     }
 
-    private Position nextHead() {
+    private Position nextHead(final Direction direction) {
         return new Position(
             body.getFirst().x() + direction.dx,
             body.getFirst().y() + direction.dy
         );
-    }
-
-    public void changeDirection(final Direction newDirection) {
-        if (!newDirection.equals(direction.opposite())) {
-            direction = newDirection;
-        }
     }
 
     public Position head() {
@@ -47,10 +33,6 @@ public class Snake {
 
     public ArrayDeque<Position> body() {
         return body;
-    }
-
-    public Direction direction() {
-        return direction;
     }
 
     public int size() {

--- a/src/main/java/com/snake/model/Snake.java
+++ b/src/main/java/com/snake/model/Snake.java
@@ -17,8 +17,8 @@ public class Snake {
         body.removeLast();
     }
 
-    public void grow(final Direction direction) {
-        body.addFirst(nextHead(direction));
+    public void grow() {
+        body.addLast(body.getLast());
     }
 
     private Position nextHead(final Direction direction) {

--- a/src/main/java/com/snake/model/Snake.java
+++ b/src/main/java/com/snake/model/Snake.java
@@ -1,6 +1,7 @@
 package com.snake.model;
 
 import java.util.ArrayDeque;
+import java.util.Deque;
 
 public class Snake {
 
@@ -31,7 +32,7 @@ public class Snake {
         return body.getFirst();
     }
 
-    public ArrayDeque<Position> body() {
+    public Deque<Position> body() {
         return body;
     }
 

--- a/src/main/java/com/snake/model/Snake.java
+++ b/src/main/java/com/snake/model/Snake.java
@@ -6,30 +6,33 @@ public class Snake {
 
     private final ArrayDeque<Position> body;
     private Direction direction;
-    private int pendingGrowth;
+    private int segmentsToAdd;
 
     public Snake(final Position start, final Direction direction) {
         this.body = new ArrayDeque<>();
         this.body.addFirst(start);
         this.direction = direction;
-        this.pendingGrowth = 0;
+        this.segmentsToAdd = 0;
     }
 
     public void move() {
-        final var newHead = new Position(
-            body.getFirst().x() + direction.dx,
-            body.getFirst().y() + direction.dy
-        );
-        body.addFirst(newHead);
-        if (pendingGrowth > 0) {
-            pendingGrowth--;
+        body.addFirst(nextHead());
+        if (segmentsToAdd > 0) {
+            segmentsToAdd--;
         } else {
             body.removeLast();
         }
     }
 
     public void grow() {
-        pendingGrowth++;
+        segmentsToAdd++;
+    }
+
+    private Position nextHead() {
+        return new Position(
+            body.getFirst().x() + direction.dx,
+            body.getFirst().y() + direction.dy
+        );
     }
 
     public void changeDirection(final Direction newDirection) {

--- a/src/main/java/com/snake/model/Snake.java
+++ b/src/main/java/com/snake/model/Snake.java
@@ -5,7 +5,7 @@ import java.util.Deque;
 
 public class Snake {
 
-    private final ArrayDeque<Position> body;
+    private final Deque<Position> body;
 
     public Snake(final Position start) {
         this.body = new ArrayDeque<>();

--- a/src/test/java/com/snake/model/SnakeTest.java
+++ b/src/test/java/com/snake/model/SnakeTest.java
@@ -3,8 +3,7 @@ package com.snake.model;
 import static com.snake.model.TestData.randomDirection;
 import static com.snake.model.TestData.randomPosition;
 import static com.snake.model.TestData.randomSnake;
-import static com.snake.model.TestData.snakeAt;
-import static com.snake.model.TestData.snakeMoving;
+import static com.snake.model.TestData.snakeWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
@@ -21,7 +20,7 @@ class SnakeTest {
     @DisplayName("head is at the starting position")
     void headIsAtStartingPosition() {
         final var start = randomPosition();
-        final var snake = snakeAt(start);
+        final var snake = snakeWith(start);
         assertThat(snake.head(), equalTo(start));
     }
 
@@ -29,14 +28,14 @@ class SnakeTest {
     @DisplayName("starts with one body segment at the starting position")
     void startsWithOneBodySegmentAtStartingPosition() {
         final var start = randomPosition();
-        final var snake = snakeAt(start);
+        final var snake = snakeWith(start);
         assertThat(snake.body(), contains(start));
     }
 
     @Test
     @DisplayName("reports the correct initial direction")
     void reportsCorrectInitialDirection() {
-        final var snake = snakeMoving(Direction.UP);
+        final var snake = snakeWith(Direction.UP);
         assertThat(snake.direction(), equalTo(Direction.UP));
     }
 
@@ -44,16 +43,17 @@ class SnakeTest {
     @DisplayName("head moves one step in current direction after move")
     void headMovesOneStepInCurrentDirection() {
         final var start = randomPosition();
-        final var snake = new Snake(start, Direction.RIGHT);
+        final var direction = randomDirection();
+        final var snake = new Snake(start, direction);
         snake.move();
-        assertThat(snake.head(), equalTo(new Position(start.x() + 1, start.y())));
+        assertThat(snake.head(), equalTo(new Position(start.x() + direction.dx, start.y() + direction.dy)));
     }
 
     @Test
     @DisplayName("old tail is removed after move")
     void oldTailIsRemovedAfterMove() {
         final var start = randomPosition();
-        final var snake = snakeAt(start);
+        final var snake = snakeWith(start);
         snake.move();
         assertThat(snake.body(), not(hasItem(start)));
     }
@@ -91,17 +91,18 @@ class SnakeTest {
     @DisplayName("body segments are in correct spatial order after growth")
     void bodySegmentsAreInCorrectSpatialOrderAfterGrowth() {
         final var start = randomPosition();
-        final var snake = new Snake(start, Direction.RIGHT);
+        final var direction = randomDirection();
+        final var snake = new Snake(start, direction);
         snake.grow();
         snake.move();
-        assertThat(snake.head(), equalTo(new Position(start.x() + 1, start.y())));
+        assertThat(snake.head(), equalTo(new Position(start.x() + direction.dx, start.y() + direction.dy)));
         assertThat(snake.body().getLast(), equalTo(start));
     }
 
     @Test
     @DisplayName("adopts new direction when change is valid")
     void adoptsNewDirectionWhenValid() {
-        final var snake = snakeMoving(Direction.RIGHT);
+        final var snake = snakeWith(Direction.RIGHT);
         snake.changeDirection(Direction.UP);
         assertThat(snake.direction(), equalTo(Direction.UP));
     }
@@ -109,7 +110,7 @@ class SnakeTest {
     @Test
     @DisplayName("ignores direction change that would reverse into itself")
     void ignoresReversalDirectionChange() {
-        final var snake = snakeMoving(Direction.RIGHT);
+        final var snake = snakeWith(Direction.RIGHT);
         snake.changeDirection(Direction.LEFT);
         assertThat(snake.direction(), equalTo(Direction.RIGHT));
     }
@@ -117,7 +118,7 @@ class SnakeTest {
     @Test
     @DisplayName("direction is unchanged after an ignored input")
     void directionUnchangedAfterIgnoredInput() {
-        final var snake = snakeMoving(Direction.UP);
+        final var snake = snakeWith(Direction.UP);
         snake.changeDirection(Direction.DOWN);
         assertThat(snake.direction(), equalTo(Direction.UP));
     }

--- a/src/test/java/com/snake/model/SnakeTest.java
+++ b/src/test/java/com/snake/model/SnakeTest.java
@@ -59,30 +59,30 @@ class SnakeTest {
     }
 
     @Test
-    @DisplayName("size increases by 1 after eat")
-    void sizeIncreasesByOneAfterEat() {
+    @DisplayName("size increases by 1 after grow")
+    void sizeIncreasesByOneAfterGrow() {
         final var snake = randomSnake();
-        snake.eat(randomDirection());
+        snake.grow(randomDirection());
         assertThat(snake.size(), equalTo(2));
     }
 
     @Test
-    @DisplayName("each eat call adds exactly one segment")
-    void eachEatCallAddsExactlyOneSegment() {
+    @DisplayName("each grow call adds exactly one segment")
+    void eachGrowCallAddsExactlyOneSegment() {
         final var snake = randomSnake();
-        snake.eat(randomDirection());
+        snake.grow(randomDirection());
         assertThat(snake.size(), equalTo(2));
-        snake.eat(randomDirection());
+        snake.grow(randomDirection());
         assertThat(snake.size(), equalTo(3));
     }
 
     @Test
-    @DisplayName("body segments are in correct spatial order after eat")
-    void bodySegmentsAreInCorrectSpatialOrderAfterEat() {
+    @DisplayName("body segments are in correct spatial order after grow")
+    void bodySegmentsAreInCorrectSpatialOrderAfterGrow() {
         final var start = randomPosition();
         final var direction = randomDirection();
         final var snake = snakeWith(start);
-        snake.eat(direction);
+        snake.grow(direction);
         assertThat(snake.head(), equalTo(positionAfterStep(start, direction)));
         assertThat(snake.body().getLast(), equalTo(start));
     }

--- a/src/test/java/com/snake/model/SnakeTest.java
+++ b/src/test/java/com/snake/model/SnakeTest.java
@@ -59,14 +59,6 @@ class SnakeTest {
     }
 
     @Test
-    @DisplayName("size increases by 1 after grow")
-    void sizeIncreasesByOneAfterGrow() {
-        final var snake = randomSnake();
-        snake.grow(randomDirection());
-        assertThat(snake.size(), equalTo(2));
-    }
-
-    @Test
     @DisplayName("each grow call adds exactly one segment")
     void eachGrowCallAddsExactlyOneSegment() {
         final var snake = randomSnake();

--- a/src/test/java/com/snake/model/SnakeTest.java
+++ b/src/test/java/com/snake/model/SnakeTest.java
@@ -71,6 +71,29 @@ class SnakeTest {
     }
 
     @Test
+    @DisplayName("tail of a multi-segment snake is removed after move")
+    void tailOfMultiSegmentSnakeIsRemovedAfterMove() {
+        final var start = randomPosition();
+        final var snake = snakeWith(start);
+        snake.grow(randomDirection());
+
+        snake.move(randomDirection());
+
+        assertThat(snake.body(), not(hasItem(start)));
+    }
+
+    @Test
+    @DisplayName("size is retained after grow then move")
+    void sizeIsRetainedAfterGrowThenMove() {
+        final var snake = randomSnake();
+        snake.grow(randomDirection());
+
+        snake.move(randomDirection());
+
+        assertThat(snake.size(), equalTo(2));
+    }
+
+    @Test
     @DisplayName("each grow call adds exactly one segment")
     void eachGrowCallAddsExactlyOneSegment() {
         final var snake = randomSnake();

--- a/src/test/java/com/snake/model/SnakeTest.java
+++ b/src/test/java/com/snake/model/SnakeTest.java
@@ -13,13 +13,6 @@ import org.junit.jupiter.api.Test;
 class SnakeTest {
 
     @Test
-    @DisplayName("starts with size 1")
-    void startsWithSizeOne() {
-        final var snake = new Snake(randomPosition(), Direction.RIGHT);
-        assertThat(snake.size(), equalTo(1));
-    }
-
-    @Test
     @DisplayName("head is at the starting position")
     void headIsAtStartingPosition() {
         final var start = randomPosition();

--- a/src/test/java/com/snake/model/SnakeTest.java
+++ b/src/test/java/com/snake/model/SnakeTest.java
@@ -1,5 +1,6 @@
 package com.snake.model;
 
+import static com.snake.model.TestData.positionAfterStep;
 import static com.snake.model.TestData.randomDirection;
 import static com.snake.model.TestData.randomPosition;
 import static com.snake.model.TestData.randomSnake;
@@ -48,7 +49,7 @@ class SnakeTest {
         final var direction = randomDirection();
         final var snake = new Snake(start, direction);
         snake.move();
-        assertThat(snake.head(), equalTo(new Position(start.x() + direction.dx, start.y() + direction.dy)));
+        assertThat(snake.head(), equalTo(positionAfterStep(start, direction)));
     }
 
     @Test
@@ -97,7 +98,7 @@ class SnakeTest {
         final var snake = new Snake(start, direction);
         snake.grow();
         snake.move();
-        assertThat(snake.head(), equalTo(new Position(start.x() + direction.dx, start.y() + direction.dy)));
+        assertThat(snake.head(), equalTo(positionAfterStep(start, direction)));
         assertThat(snake.body().getLast(), equalTo(start));
     }
 

--- a/src/test/java/com/snake/model/SnakeTest.java
+++ b/src/test/java/com/snake/model/SnakeTest.java
@@ -1,0 +1,118 @@
+package com.snake.model;
+
+import static com.snake.model.TestData.randomPosition;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Snake")
+class SnakeTest {
+
+    @Test
+    @DisplayName("starts with size 1")
+    void startsWithSizeOne() {
+        final var snake = new Snake(randomPosition(), Direction.RIGHT);
+        assertThat(snake.size(), equalTo(1));
+    }
+
+    @Test
+    @DisplayName("head is at the starting position")
+    void headIsAtStartingPosition() {
+        final var start = randomPosition();
+        final var snake = new Snake(start, Direction.RIGHT);
+        assertThat(snake.head(), equalTo(start));
+    }
+
+    @Test
+    @DisplayName("reports the correct initial direction")
+    void reportsCorrectInitialDirection() {
+        final var snake = new Snake(randomPosition(), Direction.UP);
+        assertThat(snake.direction(), equalTo(Direction.UP));
+    }
+
+    @Test
+    @DisplayName("head moves one step in current direction after move")
+    void headMovesOneStepInCurrentDirection() {
+        final var start = randomPosition();
+        final var snake = new Snake(start, Direction.RIGHT);
+        snake.move();
+        assertThat(snake.head(), equalTo(new Position(start.x() + 1, start.y())));
+    }
+
+    @Test
+    @DisplayName("old tail is removed after move")
+    void oldTailIsRemovedAfterMove() {
+        final var start = randomPosition();
+        final var snake = new Snake(start, Direction.RIGHT);
+        snake.move();
+        assertThat(snake.body(), not(hasItem(start)));
+    }
+
+    @Test
+    @DisplayName("size is unchanged after move")
+    void sizeIsUnchangedAfterMove() {
+        final var snake = new Snake(randomPosition(), Direction.DOWN);
+        snake.move();
+        assertThat(snake.size(), equalTo(1));
+    }
+
+    @Test
+    @DisplayName("size increases by 1 after grow then move")
+    void sizeIncreasesByOneAfterGrowThenMove() {
+        final var snake = new Snake(randomPosition(), Direction.RIGHT);
+        snake.grow();
+        snake.move();
+        assertThat(snake.size(), equalTo(2));
+    }
+
+    @Test
+    @DisplayName("each grow call adds exactly one segment on the next move")
+    void eachGrowCallAddsExactlyOneSegment() {
+        final var snake = new Snake(randomPosition(), Direction.RIGHT);
+        snake.grow();
+        snake.grow();
+        snake.move();
+        assertThat(snake.size(), equalTo(2));
+        snake.move();
+        assertThat(snake.size(), equalTo(3));
+    }
+
+    @Test
+    @DisplayName("body segments are in correct spatial order after growth")
+    void bodySegmentsAreInCorrectSpatialOrderAfterGrowth() {
+        final var start = randomPosition();
+        final var snake = new Snake(start, Direction.RIGHT);
+        snake.grow();
+        snake.move();
+        assertThat(snake.head(), equalTo(new Position(start.x() + 1, start.y())));
+        assertThat(snake.body().getLast(), equalTo(start));
+    }
+
+    @Test
+    @DisplayName("adopts new direction when change is valid")
+    void adoptsNewDirectionWhenValid() {
+        final var snake = new Snake(randomPosition(), Direction.RIGHT);
+        snake.changeDirection(Direction.UP);
+        assertThat(snake.direction(), equalTo(Direction.UP));
+    }
+
+    @Test
+    @DisplayName("ignores direction change that would reverse into itself")
+    void ignoresReversalDirectionChange() {
+        final var snake = new Snake(randomPosition(), Direction.RIGHT);
+        snake.changeDirection(Direction.LEFT);
+        assertThat(snake.direction(), equalTo(Direction.RIGHT));
+    }
+
+    @Test
+    @DisplayName("direction is unchanged after an ignored input")
+    void directionUnchangedAfterIgnoredInput() {
+        final var snake = new Snake(randomPosition(), Direction.UP);
+        snake.changeDirection(Direction.DOWN);
+        assertThat(snake.direction(), equalTo(Direction.UP));
+    }
+}

--- a/src/test/java/com/snake/model/SnakeTest.java
+++ b/src/test/java/com/snake/model/SnakeTest.java
@@ -21,14 +21,20 @@ class SnakeTest {
     @DisplayName("head is at the starting position")
     void headIsAtStartingPosition() {
         final var start = randomPosition();
-        assertThat(snakeWith(start).head(), equalTo(start));
+
+        final var snake = snakeWith(start);
+
+        assertThat(snake.head(), equalTo(start));
     }
 
     @Test
     @DisplayName("starts with one body segment at the starting position")
     void startsWithOneBodySegmentAtStartingPosition() {
         final var start = randomPosition();
-        assertThat(snakeWith(start).body(), contains(start));
+
+        final var snake = snakeWith(start);
+
+        assertThat(snake.body(), contains(start));
     }
 
     @Test
@@ -37,7 +43,9 @@ class SnakeTest {
         final var start = randomPosition();
         final var direction = randomDirection();
         final var snake = snakeWith(start);
+
         snake.move(direction);
+
         assertThat(snake.head(), equalTo(positionAfterStep(start, direction)));
     }
 
@@ -46,7 +54,9 @@ class SnakeTest {
     void oldTailIsRemovedAfterMove() {
         final var start = randomPosition();
         final var snake = snakeWith(start);
+
         snake.move(randomDirection());
+
         assertThat(snake.body(), not(hasItem(start)));
     }
 
@@ -54,7 +64,9 @@ class SnakeTest {
     @DisplayName("size is unchanged after move")
     void sizeIsUnchangedAfterMove() {
         final var snake = randomSnake();
+
         snake.move(randomDirection());
+
         assertThat(snake.size(), equalTo(1));
     }
 
@@ -62,8 +74,10 @@ class SnakeTest {
     @DisplayName("each grow call adds exactly one segment")
     void eachGrowCallAddsExactlyOneSegment() {
         final var snake = randomSnake();
+
         snake.grow(randomDirection());
         assertThat(snake.size(), equalTo(2));
+
         snake.grow(randomDirection());
         assertThat(snake.size(), equalTo(3));
     }
@@ -74,7 +88,9 @@ class SnakeTest {
         final var start = randomPosition();
         final var direction = randomDirection();
         final var snake = snakeWith(start);
+
         snake.grow(direction);
+
         assertThat(snake.head(), equalTo(positionAfterStep(start, direction)));
         assertThat(snake.body().getLast(), equalTo(start));
     }

--- a/src/test/java/com/snake/model/SnakeTest.java
+++ b/src/test/java/com/snake/model/SnakeTest.java
@@ -71,26 +71,25 @@ class SnakeTest {
     }
 
     @Test
-    @DisplayName("tail of a multi-segment snake is removed after move")
-    void tailOfMultiSegmentSnakeIsRemovedAfterMove() {
+    @DisplayName("grow does not move the head")
+    void growDoesNotMoveHead() {
         final var start = randomPosition();
         final var snake = snakeWith(start);
-        snake.grow(randomDirection());
 
-        snake.move(randomDirection());
+        snake.grow();
 
-        assertThat(snake.body(), not(hasItem(start)));
+        assertThat(snake.head(), equalTo(start));
     }
 
     @Test
-    @DisplayName("size is retained after grow then move")
-    void sizeIsRetainedAfterGrowThenMove() {
-        final var snake = randomSnake();
-        snake.grow(randomDirection());
+    @DisplayName("grow adds one segment at the tail")
+    void growAddsOneSegmentAtTail() {
+        final var start = randomPosition();
+        final var snake = snakeWith(start);
 
-        snake.move(randomDirection());
+        snake.grow();
 
-        assertThat(snake.size(), equalTo(2));
+        assertThat(snake.body(), contains(start, start));
     }
 
     @Test
@@ -98,21 +97,33 @@ class SnakeTest {
     void eachGrowCallAddsExactlyOneSegment() {
         final var snake = randomSnake();
 
-        snake.grow(randomDirection());
+        snake.grow();
         assertThat(snake.size(), equalTo(2));
 
-        snake.grow(randomDirection());
+        snake.grow();
         assertThat(snake.size(), equalTo(3));
     }
 
     @Test
-    @DisplayName("body segments are in correct spatial order after grow")
-    void bodySegmentsAreInCorrectSpatialOrderAfterGrow() {
+    @DisplayName("size is retained after grow then move")
+    void sizeIsRetainedAfterGrowThenMove() {
+        final var snake = randomSnake();
+        snake.grow();
+
+        snake.move(randomDirection());
+
+        assertThat(snake.size(), equalTo(2));
+    }
+
+    @Test
+    @DisplayName("body is in correct spatial order after grow then move")
+    void bodyIsInCorrectSpatialOrderAfterGrowThenMove() {
         final var start = randomPosition();
         final var direction = randomDirection();
         final var snake = snakeWith(start);
+        snake.grow();
 
-        snake.grow(direction);
+        snake.move(direction);
 
         assertThat(snake.head(), equalTo(positionAfterStep(start, direction)));
         assertThat(snake.body().getLast(), equalTo(start));

--- a/src/test/java/com/snake/model/SnakeTest.java
+++ b/src/test/java/com/snake/model/SnakeTest.java
@@ -47,7 +47,7 @@ class SnakeTest {
     void headMovesOneStepInCurrentDirection() {
         final var start = randomPosition();
         final var direction = randomDirection();
-        final var snake = new Snake(start, direction);
+        final var snake = snakeWith(start, direction);
         snake.move();
         assertThat(snake.head(), equalTo(positionAfterStep(start, direction)));
     }
@@ -95,7 +95,7 @@ class SnakeTest {
     void bodySegmentsAreInCorrectSpatialOrderAfterGrowth() {
         final var start = randomPosition();
         final var direction = randomDirection();
-        final var snake = new Snake(start, direction);
+        final var snake = snakeWith(start, direction);
         snake.grow();
         snake.move();
         assertThat(snake.head(), equalTo(positionAfterStep(start, direction)));

--- a/src/test/java/com/snake/model/SnakeTest.java
+++ b/src/test/java/com/snake/model/SnakeTest.java
@@ -2,6 +2,7 @@ package com.snake.model;
 
 import static com.snake.model.TestData.randomPosition;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
@@ -18,6 +19,14 @@ class SnakeTest {
         final var start = randomPosition();
         final var snake = new Snake(start, Direction.RIGHT);
         assertThat(snake.head(), equalTo(start));
+    }
+
+    @Test
+    @DisplayName("starts with one body segment at the starting position")
+    void startsWithOneBodySegmentAtStartingPosition() {
+        final var start = randomPosition();
+        final var snake = new Snake(start, Direction.RIGHT);
+        assertThat(snake.body(), contains(start));
     }
 
     @Test

--- a/src/test/java/com/snake/model/SnakeTest.java
+++ b/src/test/java/com/snake/model/SnakeTest.java
@@ -105,11 +105,11 @@ class SnakeTest {
     }
 
     @Test
-    @DisplayName("size is retained after grow then move")
+    @DisplayName("size is retained after grows then move")
     void sizeIsRetainedAfterGrowThenMove() {
         final var snake = randomSnake();
-        snake.grow();
 
+        snake.grow();
         snake.move(randomDirection());
 
         assertThat(snake.size(), equalTo(2));

--- a/src/test/java/com/snake/model/SnakeTest.java
+++ b/src/test/java/com/snake/model/SnakeTest.java
@@ -4,7 +4,6 @@ import static com.snake.model.TestData.positionAfterStep;
 import static com.snake.model.TestData.randomDirection;
 import static com.snake.model.TestData.randomPosition;
 import static com.snake.model.TestData.randomSnake;
-import static com.snake.model.TestData.randomValidChangeFrom;
 import static com.snake.model.TestData.snakeWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
@@ -22,33 +21,23 @@ class SnakeTest {
     @DisplayName("head is at the starting position")
     void headIsAtStartingPosition() {
         final var start = randomPosition();
-        final var snake = snakeWith(start);
-        assertThat(snake.head(), equalTo(start));
+        assertThat(snakeWith(start).head(), equalTo(start));
     }
 
     @Test
     @DisplayName("starts with one body segment at the starting position")
     void startsWithOneBodySegmentAtStartingPosition() {
         final var start = randomPosition();
-        final var snake = snakeWith(start);
-        assertThat(snake.body(), contains(start));
+        assertThat(snakeWith(start).body(), contains(start));
     }
 
     @Test
-    @DisplayName("reports the correct initial direction")
-    void reportsCorrectInitialDirection() {
-        final var direction = randomDirection();
-        final var snake = snakeWith(direction);
-        assertThat(snake.direction(), equalTo(direction));
-    }
-
-    @Test
-    @DisplayName("head moves one step in current direction after move")
-    void headMovesOneStepInCurrentDirection() {
+    @DisplayName("head moves one step in the given direction after move")
+    void headMovesOneStepInGivenDirection() {
         final var start = randomPosition();
         final var direction = randomDirection();
-        final var snake = snakeWith(start, direction);
-        snake.move();
+        final var snake = snakeWith(start);
+        snake.move(direction);
         assertThat(snake.head(), equalTo(positionAfterStep(start, direction)));
     }
 
@@ -57,7 +46,7 @@ class SnakeTest {
     void oldTailIsRemovedAfterMove() {
         final var start = randomPosition();
         final var snake = snakeWith(start);
-        snake.move();
+        snake.move(randomDirection());
         assertThat(snake.body(), not(hasItem(start)));
     }
 
@@ -65,68 +54,36 @@ class SnakeTest {
     @DisplayName("size is unchanged after move")
     void sizeIsUnchangedAfterMove() {
         final var snake = randomSnake();
-        snake.move();
+        snake.move(randomDirection());
         assertThat(snake.size(), equalTo(1));
     }
 
     @Test
-    @DisplayName("size increases by 1 after grow then move")
-    void sizeIncreasesByOneAfterGrowThenMove() {
+    @DisplayName("size increases by 1 after eat")
+    void sizeIncreasesByOneAfterEat() {
         final var snake = randomSnake();
-        snake.grow();
-        snake.move();
+        snake.eat(randomDirection());
         assertThat(snake.size(), equalTo(2));
     }
 
     @Test
-    @DisplayName("each grow call adds exactly one segment on the next move")
-    void eachGrowCallAddsExactlyOneSegment() {
+    @DisplayName("each eat call adds exactly one segment")
+    void eachEatCallAddsExactlyOneSegment() {
         final var snake = randomSnake();
-        snake.grow();
-        snake.grow();
-        snake.move();
+        snake.eat(randomDirection());
         assertThat(snake.size(), equalTo(2));
-        snake.move();
+        snake.eat(randomDirection());
         assertThat(snake.size(), equalTo(3));
     }
 
     @Test
-    @DisplayName("body segments are in correct spatial order after growth")
-    void bodySegmentsAreInCorrectSpatialOrderAfterGrowth() {
+    @DisplayName("body segments are in correct spatial order after eat")
+    void bodySegmentsAreInCorrectSpatialOrderAfterEat() {
         final var start = randomPosition();
         final var direction = randomDirection();
-        final var snake = snakeWith(start, direction);
-        snake.grow();
-        snake.move();
+        final var snake = snakeWith(start);
+        snake.eat(direction);
         assertThat(snake.head(), equalTo(positionAfterStep(start, direction)));
         assertThat(snake.body().getLast(), equalTo(start));
-    }
-
-    @Test
-    @DisplayName("adopts new direction when change is valid")
-    void adoptsNewDirectionWhenValid() {
-        final var direction = randomDirection();
-        final var snake = snakeWith(direction);
-        final var validChange = randomValidChangeFrom(direction);
-        snake.changeDirection(validChange);
-        assertThat(snake.direction(), equalTo(validChange));
-    }
-
-    @Test
-    @DisplayName("ignores direction change that would reverse into itself")
-    void ignoresReversalDirectionChange() {
-        final var direction = randomDirection();
-        final var snake = snakeWith(direction);
-        snake.changeDirection(direction.opposite());
-        assertThat(snake.direction(), equalTo(direction));
-    }
-
-    @Test
-    @DisplayName("direction is unchanged after an ignored input")
-    void directionUnchangedAfterIgnoredInput() {
-        final var direction = randomDirection();
-        final var snake = snakeWith(direction);
-        snake.changeDirection(direction.opposite());
-        assertThat(snake.direction(), equalTo(direction));
     }
 }

--- a/src/test/java/com/snake/model/SnakeTest.java
+++ b/src/test/java/com/snake/model/SnakeTest.java
@@ -121,8 +121,8 @@ class SnakeTest {
         final var start = randomPosition();
         final var direction = randomDirection();
         final var snake = snakeWith(start);
-        snake.grow();
 
+        snake.grow();
         snake.move(direction);
 
         assertThat(snake.head(), equalTo(positionAfterStep(start, direction)));

--- a/src/test/java/com/snake/model/SnakeTest.java
+++ b/src/test/java/com/snake/model/SnakeTest.java
@@ -1,6 +1,10 @@
 package com.snake.model;
 
+import static com.snake.model.TestData.randomDirection;
 import static com.snake.model.TestData.randomPosition;
+import static com.snake.model.TestData.randomSnake;
+import static com.snake.model.TestData.snakeAt;
+import static com.snake.model.TestData.snakeMoving;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
@@ -17,7 +21,7 @@ class SnakeTest {
     @DisplayName("head is at the starting position")
     void headIsAtStartingPosition() {
         final var start = randomPosition();
-        final var snake = new Snake(start, Direction.RIGHT);
+        final var snake = snakeAt(start);
         assertThat(snake.head(), equalTo(start));
     }
 
@@ -25,14 +29,14 @@ class SnakeTest {
     @DisplayName("starts with one body segment at the starting position")
     void startsWithOneBodySegmentAtStartingPosition() {
         final var start = randomPosition();
-        final var snake = new Snake(start, Direction.RIGHT);
+        final var snake = snakeAt(start);
         assertThat(snake.body(), contains(start));
     }
 
     @Test
     @DisplayName("reports the correct initial direction")
     void reportsCorrectInitialDirection() {
-        final var snake = new Snake(randomPosition(), Direction.UP);
+        final var snake = snakeMoving(Direction.UP);
         assertThat(snake.direction(), equalTo(Direction.UP));
     }
 
@@ -49,7 +53,7 @@ class SnakeTest {
     @DisplayName("old tail is removed after move")
     void oldTailIsRemovedAfterMove() {
         final var start = randomPosition();
-        final var snake = new Snake(start, Direction.RIGHT);
+        final var snake = snakeAt(start);
         snake.move();
         assertThat(snake.body(), not(hasItem(start)));
     }
@@ -57,7 +61,7 @@ class SnakeTest {
     @Test
     @DisplayName("size is unchanged after move")
     void sizeIsUnchangedAfterMove() {
-        final var snake = new Snake(randomPosition(), Direction.DOWN);
+        final var snake = randomSnake();
         snake.move();
         assertThat(snake.size(), equalTo(1));
     }
@@ -65,7 +69,7 @@ class SnakeTest {
     @Test
     @DisplayName("size increases by 1 after grow then move")
     void sizeIncreasesByOneAfterGrowThenMove() {
-        final var snake = new Snake(randomPosition(), Direction.RIGHT);
+        final var snake = randomSnake();
         snake.grow();
         snake.move();
         assertThat(snake.size(), equalTo(2));
@@ -74,7 +78,7 @@ class SnakeTest {
     @Test
     @DisplayName("each grow call adds exactly one segment on the next move")
     void eachGrowCallAddsExactlyOneSegment() {
-        final var snake = new Snake(randomPosition(), Direction.RIGHT);
+        final var snake = randomSnake();
         snake.grow();
         snake.grow();
         snake.move();
@@ -97,7 +101,7 @@ class SnakeTest {
     @Test
     @DisplayName("adopts new direction when change is valid")
     void adoptsNewDirectionWhenValid() {
-        final var snake = new Snake(randomPosition(), Direction.RIGHT);
+        final var snake = snakeMoving(Direction.RIGHT);
         snake.changeDirection(Direction.UP);
         assertThat(snake.direction(), equalTo(Direction.UP));
     }
@@ -105,7 +109,7 @@ class SnakeTest {
     @Test
     @DisplayName("ignores direction change that would reverse into itself")
     void ignoresReversalDirectionChange() {
-        final var snake = new Snake(randomPosition(), Direction.RIGHT);
+        final var snake = snakeMoving(Direction.RIGHT);
         snake.changeDirection(Direction.LEFT);
         assertThat(snake.direction(), equalTo(Direction.RIGHT));
     }
@@ -113,7 +117,7 @@ class SnakeTest {
     @Test
     @DisplayName("direction is unchanged after an ignored input")
     void directionUnchangedAfterIgnoredInput() {
-        final var snake = new Snake(randomPosition(), Direction.UP);
+        final var snake = snakeMoving(Direction.UP);
         snake.changeDirection(Direction.DOWN);
         assertThat(snake.direction(), equalTo(Direction.UP));
     }

--- a/src/test/java/com/snake/model/SnakeTest.java
+++ b/src/test/java/com/snake/model/SnakeTest.java
@@ -3,6 +3,7 @@ package com.snake.model;
 import static com.snake.model.TestData.randomDirection;
 import static com.snake.model.TestData.randomPosition;
 import static com.snake.model.TestData.randomSnake;
+import static com.snake.model.TestData.randomValidChangeFrom;
 import static com.snake.model.TestData.snakeWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
@@ -35,8 +36,9 @@ class SnakeTest {
     @Test
     @DisplayName("reports the correct initial direction")
     void reportsCorrectInitialDirection() {
-        final var snake = snakeWith(Direction.UP);
-        assertThat(snake.direction(), equalTo(Direction.UP));
+        final var direction = randomDirection();
+        final var snake = snakeWith(direction);
+        assertThat(snake.direction(), equalTo(direction));
     }
 
     @Test
@@ -102,24 +104,28 @@ class SnakeTest {
     @Test
     @DisplayName("adopts new direction when change is valid")
     void adoptsNewDirectionWhenValid() {
-        final var snake = snakeWith(Direction.RIGHT);
-        snake.changeDirection(Direction.UP);
-        assertThat(snake.direction(), equalTo(Direction.UP));
+        final var direction = randomDirection();
+        final var snake = snakeWith(direction);
+        final var validChange = randomValidChangeFrom(direction);
+        snake.changeDirection(validChange);
+        assertThat(snake.direction(), equalTo(validChange));
     }
 
     @Test
     @DisplayName("ignores direction change that would reverse into itself")
     void ignoresReversalDirectionChange() {
-        final var snake = snakeWith(Direction.RIGHT);
-        snake.changeDirection(Direction.LEFT);
-        assertThat(snake.direction(), equalTo(Direction.RIGHT));
+        final var direction = randomDirection();
+        final var snake = snakeWith(direction);
+        snake.changeDirection(direction.opposite());
+        assertThat(snake.direction(), equalTo(direction));
     }
 
     @Test
     @DisplayName("direction is unchanged after an ignored input")
     void directionUnchangedAfterIgnoredInput() {
-        final var snake = snakeWith(Direction.UP);
-        snake.changeDirection(Direction.DOWN);
-        assertThat(snake.direction(), equalTo(Direction.UP));
+        final var direction = randomDirection();
+        final var snake = snakeWith(direction);
+        snake.changeDirection(direction.opposite());
+        assertThat(snake.direction(), equalTo(direction));
     }
 }

--- a/src/test/java/com/snake/model/TestData.java
+++ b/src/test/java/com/snake/model/TestData.java
@@ -1,6 +1,5 @@
 package com.snake.model;
 
-import java.util.Arrays;
 import java.util.concurrent.ThreadLocalRandom;
 
 final class TestData {

--- a/src/test/java/com/snake/model/TestData.java
+++ b/src/test/java/com/snake/model/TestData.java
@@ -1,5 +1,6 @@
 package com.snake.model;
 
+import java.util.Arrays;
 import java.util.concurrent.ThreadLocalRandom;
 
 final class TestData {
@@ -29,5 +30,12 @@ final class TestData {
 
     static Snake snakeWith(final Direction direction) {
         return new Snake(randomPosition(), direction);
+    }
+
+    static Direction randomValidChangeFrom(final Direction current) {
+        final var valid = Arrays.stream(Direction.values())
+            .filter(d -> !d.equals(current) && !d.equals(current.opposite()))
+            .toList();
+        return valid.get(ThreadLocalRandom.current().nextInt(valid.size()));
     }
 }

--- a/src/test/java/com/snake/model/TestData.java
+++ b/src/test/java/com/snake/model/TestData.java
@@ -13,4 +13,21 @@ final class TestData {
     static Position randomPosition() {
         return new Position(randomCoordinate(), randomCoordinate());
     }
+
+    static Direction randomDirection() {
+        final var values = Direction.values();
+        return values[ThreadLocalRandom.current().nextInt(values.length)];
+    }
+
+    static Snake randomSnake() {
+        return new Snake(randomPosition(), randomDirection());
+    }
+
+    static Snake snakeAt(final Position start) {
+        return new Snake(start, randomDirection());
+    }
+
+    static Snake snakeMoving(final Direction direction) {
+        return new Snake(randomPosition(), direction);
+    }
 }

--- a/src/test/java/com/snake/model/TestData.java
+++ b/src/test/java/com/snake/model/TestData.java
@@ -23,11 +23,11 @@ final class TestData {
         return new Snake(randomPosition(), randomDirection());
     }
 
-    static Snake snakeAt(final Position start) {
+    static Snake snakeWith(final Position start) {
         return new Snake(start, randomDirection());
     }
 
-    static Snake snakeMoving(final Direction direction) {
+    static Snake snakeWith(final Direction direction) {
         return new Snake(randomPosition(), direction);
     }
 }

--- a/src/test/java/com/snake/model/TestData.java
+++ b/src/test/java/com/snake/model/TestData.java
@@ -21,29 +21,14 @@ final class TestData {
     }
 
     static Snake randomSnake() {
-        return new Snake(randomPosition(), randomDirection());
+        return new Snake(randomPosition());
     }
 
     static Snake snakeWith(final Position start) {
-        return new Snake(start, randomDirection());
-    }
-
-    static Snake snakeWith(final Direction direction) {
-        return new Snake(randomPosition(), direction);
-    }
-
-    static Snake snakeWith(final Position start, final Direction direction) {
-        return new Snake(start, direction);
+        return new Snake(start);
     }
 
     static Position positionAfterStep(final Position from, final Direction direction) {
         return new Position(from.x() + direction.dx, from.y() + direction.dy);
-    }
-
-    static Direction randomValidChangeFrom(final Direction current) {
-        final var valid = Arrays.stream(Direction.values())
-            .filter(d -> !d.equals(current) && !d.equals(current.opposite()))
-            .toList();
-        return valid.get(ThreadLocalRandom.current().nextInt(valid.size()));
     }
 }

--- a/src/test/java/com/snake/model/TestData.java
+++ b/src/test/java/com/snake/model/TestData.java
@@ -32,6 +32,10 @@ final class TestData {
         return new Snake(randomPosition(), direction);
     }
 
+    static Position positionAfterStep(final Position from, final Direction direction) {
+        return new Position(from.x() + direction.dx, from.y() + direction.dy);
+    }
+
     static Direction randomValidChangeFrom(final Direction current) {
         final var valid = Arrays.stream(Direction.values())
             .filter(d -> !d.equals(current) && !d.equals(current.opposite()))

--- a/src/test/java/com/snake/model/TestData.java
+++ b/src/test/java/com/snake/model/TestData.java
@@ -32,6 +32,10 @@ final class TestData {
         return new Snake(randomPosition(), direction);
     }
 
+    static Snake snakeWith(final Position start, final Direction direction) {
+        return new Snake(start, direction);
+    }
+
     static Position positionAfterStep(final Position from, final Direction direction) {
         return new Position(from.x() + direction.dx, from.y() + direction.dy);
     }


### PR DESCRIPTION
## Summary
Implements all `Snake` behaviours — initialization, movement, growth, and direction change.

Closes #8, #9, #10, #11

## Design decisions
- **`ArrayDeque`** — O(1) `addFirst`/`removeLast`, no Node wrapper per element
- **`pendingGrowth` counter** — `grow()` increments it; each `move()` skips tail removal once per pending count
- **Direction reversal blocked** — `changeDirection` silently ignores any direction equal to `direction.opposite()`

## Review checklist
- [x] `move()` — understand why `addFirst` / `removeLast`
- [x] `pendingGrowth` — trace two consecutive `grow()` + `move()` calls
- [x] `changeDirection` — why check `opposite()` instead of a hardcoded switch?
- [x] All 26 tests pass (`mvn test`)