### PR TITLE
docs: add project CLAUDE.md and pre-task design protocol

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,9 @@
+# Snake Project — Claude Rules
+
+## Before Starting Any Work
+Always pull the latest changes from remote before beginning a new task:
+```
+git checkout main
+git pull origin main
+git checkout -b <branch-name>
+```

--- a/.claude/learnings.md
+++ b/.claude/learnings.md
@@ -125,3 +125,51 @@ originSessionId: 14da0b73-34c5-44eb-9897-ae12b5e2d7c0
 - Issues and plan must reflect current design — stale descriptions mislead future work
 - Close issues only after the PR is merged, not when implementation is complete on the branch
 - Review comments on issues should be deleted when they become inaccurate
+
+---
+
+## Pre-Task Design Protocol (Born From Phase 1 Mistakes)
+
+The `eat(Direction)` → `grow(Direction)` → `grow()` journey cost test rewrites, multiple commits, and back-and-forth. All of it could have been resolved in the plan phase. Use this protocol before writing any code for a new class or method.
+
+### Step 1 — Map Responsibility Boundaries
+
+For every class involved in the task, write one sentence:
+> "This class knows: ___ and is responsible for: ___"
+
+If that sentence contains "and also", split the class. This is what would have caught `Snake` storing direction — the sentence becomes "Snake knows its body **and also the last direction the engine chose**", which immediately signals engine concern leaked into Snake.
+
+### Step 2 — Interrogate Every Method Parameter
+
+For each planned method, ask:
+- **"Where does this value come from?"** — the object that owns it is the one that should pass it, not receive it
+- **"Would this method make sense if the object didn't know about X?"** — if yes, X doesn't belong as a parameter
+- **"Can this object compute this itself, or does it require outside knowledge?"** — if outside knowledge, the method is in the wrong place
+
+This is the question that would have killed `grow(Direction)` immediately: the snake has no food or direction state, so why would grow need a direction?
+
+### Step 3 — Name Before You Code
+
+Write the method call in plain English before writing the body:
+- `snake.eat(direction)` → "does the snake know about food?" → no → wrong name, wrong responsibility
+- `snake.grow()` → "is growing a body operation?" → yes → correct
+
+**Rule:** if a method name borrows a concept from another object (food → eat, board → collide, engine → reverse), that's a signal the responsibility is misplaced. Fix the name, and the design follows.
+
+### Step 4 — Ask "What Would Have to Change?"
+
+Pick one likely future requirement and trace the impact:
+> "If we change how food is placed, which objects need to change?"
+
+If the answer includes objects that logically shouldn't care (e.g., Snake changes because food logic changed), the design is leaky. Good boundaries mean each change ripples only within the object that owns that concern.
+
+### Questions to Ask Claude at the Start of Each Task
+
+Before writing any code:
+1. "For each class in this task, what does it know and what is it responsible for — write one sentence per class."
+2. "For each planned method, does every parameter make sense strictly from this object's perspective?"
+3. "Are any of the method names borrowing a concept from another object?"
+4. "If I change [one requirement], which objects would need to change — does that make sense?"
+5. "Show me a minimal skeleton with signatures only — no bodies — and let's validate the design before implementing."
+
+Resolving these in the plan phase costs minutes. Resolving them after tests are written costs hours.

--- a/.claude/learnings.md
+++ b/.claude/learnings.md
@@ -1,0 +1,127 @@
+---
+name: Snake Session Learnings
+description: Concepts and design decisions learned during the Snake Phase 1 implementation session
+originSessionId: 14da0b73-34c5-44eb-9897-ae12b5e2d7c0
+---
+# Snake Session Learnings
+
+## Data Structures
+
+### ArrayDeque as a Deque
+- `Deque` = **D**ouble **E**nded **Queue** — add and remove from both ends in O(1)
+- `ArrayDeque` is the implementation; `Deque` is the interface we expose publicly
+- Unlike a `List`, you cannot access elements by index — only the two ends
+- For Snake this is perfect: we only ever need the head (front) and tail (back)
+- `ArrayList.add(0, element)` shifts every element — O(n). `ArrayDeque.addFirst()` is always O(1)
+
+### Head and Tail Convention
+- Head = first element (`getFirst()`), Tail = last element (`getLast()`)
+- This is a convention, not a technical requirement — it could be flipped
+- We chose front = head because it reads naturally
+- Encapsulation hides this: the engine only calls `snake.head()` and never knows which end it came from
+
+## Design Principles
+
+### Single Responsibility
+- Each method should do exactly one thing
+- `grow(Direction)` was doing two things (move + extend) — that was wrong
+- Splitting into `move(Direction)` + `grow()` gave each method a single responsibility
+
+### What Does an Object Know?
+- The most important question in the plan phase: "what does this object know about the world?"
+- Snake knows only its own body — nothing about food, the board, direction history, or game rules
+- This question, asked early, would have led directly to the right design:
+  - No stored direction in Snake → direction comes from engine on each call
+  - `grow()` needs no direction → growing is a body operation, not a movement
+  - Collision detection out of Snake → Snake has no board knowledge
+
+### Object Responsibility Boundaries
+- Snake: body state only — `move(Direction)`, `grow()`, `head()`, `body()`, `size()`
+- GameEngine: direction state, reversal guard, food collision, tick control
+- CollisionDetector: wall collision, self collision
+- Snake grows from the **tail** (not the head) — growing from the head would be a move
+
+### grow() Design Journey
+- First design: `grow(Direction)` — moved head AND kept tail (two responsibilities)
+- Second insight: grow should be a pure body operation — head stays, tail extends
+- Final design: `grow()` duplicates `getLast()` — no direction, no movement
+- The engine always calls `move(Direction)` every tick, and additionally calls `grow()` on food collision
+
+### Naming Reflects Perspective
+- `eat(Direction)` was wrong — the snake doesn't know about food, so "eat" leaks the engine's concept into the snake
+- `grow()` is correct — from the snake's perspective, it just gets longer
+
+### Don't Over-Engineer
+- `GameEntity` interface not added yet — only one character exists
+- The right time to add an interface is when you have real requirements (two characters that need to be treated uniformly)
+- Good design now = keeping Snake clean and isolated so the interface can be added later with one line
+
+### Future-Proof Without Speculating
+- If a `GameEntity` interface is added later, Snake would just implement `occupiedPositions()` delegating to `body()`
+- No logic changes needed — encapsulation already hides the implementation
+
+## Testing
+
+### Test Context (@BeforeEach + @Nested) vs Helper Methods
+- `@BeforeEach` + `@Nested` breaks the `final` rule — fields must be mutable instance variables
+- CLAUDE.md: each test owns its inputs as local `final var`
+- Helper methods (`snakeWith`, `randomSnake`, `snakeMoving`) give the same readability without shared mutable state
+- Test context fits immutable objects that are expensive to construct — not Snake
+
+### Overloaded Helpers
+- `snakeWith(Position)` and `snakeWith(Direction)` — overloads communicate what the test cares about
+- Test that cares about position: `snakeWith(start)` — direction is irrelevant
+- Test that cares about direction: `snakeWith(direction)` — position is irrelevant
+- `snakeAt()`/`snakeMoving()` were worse names — `snakeWith()` reads naturally
+
+### Randomizing Test Data
+- Hardcoded directions like `Direction.RIGHT` mean the test only proves behavior for that one case
+- `randomDirection()` proves the behavior holds for any direction
+- For `headMovesOneStepInGivenDirection`: use `direction.dx`/`direction.dy` to compute expected position dynamically
+- Only fix a value when the test is specifically about that value (e.g. boundary tests)
+
+### Removing Redundant Tests
+- `sizeIncreasesByOneAfterGrow` was redundant — `bodySegmentsAreInCorrectSpatialOrderAfterGrow` already proved size=2 implicitly
+- If spatial order is correct, size is correct by definition
+
+### When NOT to Parameterize
+- CLAUDE.md: parameterize when tests share the same assertion logic and differ only in inputs
+- `eachGrowCallAddsExactlyOneSegment` has two sequential cycles on the same snake instance — cannot parameterize without changing the test's meaning
+- The second grow tests behavior on an already-grown snake, which is distinct from the first
+
+### Set-Act-Verify Structure
+- Blank lines between phases make the test phases scannable at a glance
+- When grow + move are together in the act phase, they express a single combined action
+
+## Working With Claude Effectively
+
+### Catch Design Problems in the Plan Phase
+- The `grow(Direction)` redesign happened mid-implementation — it cost test rewrites, multiple commits, and back-and-forth
+- The root question "does the snake know it ate food?" would have resolved it in seconds during planning
+- **Rule: in the plan phase, for every method, ask Claude: "what does this object know, and does this parameter make sense from its perspective?"**
+- This is cheaper than fixing a test suite
+
+### Challenge the Semantics, Not Just the Structure
+- It's easy to agree on structure (Snake has move, grow, direction) without questioning what each method means
+- `eat(Direction)` passed a structure review — it only failed a semantics review: "the snake doesn't know about food"
+- Push Claude to justify every parameter: "why does grow need a direction?"
+
+### Name Things From the Object's Perspective
+- If a name leaks another object's concept (food → eat, game over → die), that's a signal the responsibility is wrong
+- Names reveal design problems before code does
+
+### Brainstorm Before Implementing
+- The `grow()` design had three iterations — all the reasoning could have happened in a 5-minute brainstorm
+- Before implementing: ask Claude "show me pros and cons of both approaches" — it surfaces tradeoffs without writing a line of code
+
+## Workflow
+
+### Plan Phase Questions to Ask
+- "What does this object know about the world?" → reveals wrong responsibilities before any code
+- "Does this parameter make sense from this object's perspective?" → catches `grow(Direction)` before implementation
+- Cheaper to fix a concept than a test suite
+
+### GitHub Issues and Plan Accuracy
+- Issues and plan must reflect current design — stale descriptions mislead future work
+- Close issues only after the PR is merged, not when implementation is complete on the branch
+- Review comments on issues should be deleted when they become inaccurate

--- a/.claude/learnings.md
+++ b/.claude/learnings.md
@@ -8,168 +8,89 @@ originSessionId: 14da0b73-34c5-44eb-9897-ae12b5e2d7c0
 ## Data Structures
 
 ### ArrayDeque as a Deque
-- `Deque` = **D**ouble **E**nded **Queue** — add and remove from both ends in O(1)
-- `ArrayDeque` is the implementation; `Deque` is the interface we expose publicly
-- Unlike a `List`, you cannot access elements by index — only the two ends
-- For Snake this is perfect: we only ever need the head (front) and tail (back)
-- `ArrayList.add(0, element)` shifts every element — O(n). `ArrayDeque.addFirst()` is always O(1)
-
-### Head and Tail Convention
-- Head = first element (`getFirst()`), Tail = last element (`getLast()`)
-- This is a convention, not a technical requirement — it could be flipped
-- We chose front = head because it reads naturally
-- Encapsulation hides this: the engine only calls `snake.head()` and never knows which end it came from
+- `Deque` = Double Ended Queue — add/remove from both ends in O(1)
+- `ArrayDeque` is the implementation; `Deque` is the interface we expose
+- `ArrayList.add(0, element)` is O(n); `ArrayDeque.addFirst()` is O(1)
+- Head = `getFirst()`, Tail = `getLast()` — convention, not a technical requirement
+- Encapsulation hides this: the engine calls `snake.head()` and never knows which end
 
 ## Design Principles
 
-### Single Responsibility
-- Each method should do exactly one thing
-- `grow(Direction)` was doing two things (move + extend) — that was wrong
-- Splitting into `move(Direction)` + `grow()` gave each method a single responsibility
-
-### What Does an Object Know?
-- The most important question in the plan phase: "what does this object know about the world?"
-- Snake knows only its own body — nothing about food, the board, direction history, or game rules
-- This question, asked early, would have led directly to the right design:
-  - No stored direction in Snake → direction comes from engine on each call
-  - `grow()` needs no direction → growing is a body operation, not a movement
-  - Collision detection out of Snake → Snake has no board knowledge
-
-### Object Responsibility Boundaries
+### Responsibility Boundaries
+- Write one sentence per class: "This class knows ___ and is responsible for ___"
+- If the sentence contains "and also", split the class
 - Snake: body state only — `move(Direction)`, `grow()`, `head()`, `body()`, `size()`
 - GameEngine: direction state, reversal guard, food collision, tick control
-- CollisionDetector: wall collision, self collision
-- Snake grows from the **tail** (not the head) — growing from the head would be a move
+- CollisionDetector: wall and self collision
 
 ### grow() Design Journey
 - First design: `grow(Direction)` — moved head AND kept tail (two responsibilities)
-- Second insight: grow should be a pure body operation — head stays, tail extends
-- Final design: `grow()` duplicates `getLast()` — no direction, no movement
-- The engine always calls `move(Direction)` every tick, and additionally calls `grow()` on food collision
+- Fix: grow is a pure body operation — tail extends, head stays, no direction needed
+- Engine calls `move()` every tick and `grow()` additionally on food collision
 
-### Naming Reflects Perspective
-- `eat(Direction)` was wrong — the snake doesn't know about food, so "eat" leaks the engine's concept into the snake
+### Names Reveal Design Problems
+- `eat(Direction)` passed a structure review — failed a semantics review: "the snake doesn't know about food"
 - `grow()` is correct — from the snake's perspective, it just gets longer
+- If a name borrows another object's concept (food → eat, board → collide), the responsibility is misplaced
 
 ### Don't Over-Engineer
-- `GameEntity` interface not added yet — only one character exists
-- The right time to add an interface is when you have real requirements (two characters that need to be treated uniformly)
-- Good design now = keeping Snake clean and isolated so the interface can be added later with one line
-
-### Future-Proof Without Speculating
-- If a `GameEntity` interface is added later, Snake would just implement `occupiedPositions()` delegating to `body()`
-- No logic changes needed — encapsulation already hides the implementation
+- Add interfaces only when two real things need to be treated uniformly
+- Good encapsulation now means an interface can be added later with one line, no logic changes
 
 ## Testing
 
-### Test Context (@BeforeEach + @Nested) vs Helper Methods
-- `@BeforeEach` + `@Nested` breaks the `final` rule — fields must be mutable instance variables
-- CLAUDE.md: each test owns its inputs as local `final var`
-- Helper methods (`snakeWith`, `randomSnake`, `snakeMoving`) give the same readability without shared mutable state
-- Test context fits immutable objects that are expensive to construct — not Snake
+### Helper Methods Over @BeforeEach
+- `@BeforeEach` + `@Nested` forces mutable fields — breaks the `final` rule
+- Helper methods (`snakeWith`, `randomSnake`) give the same readability without shared mutable state
+- `snakeWith(Position)` vs `snakeWith(Direction)` — overloads communicate what the test cares about
 
-### Overloaded Helpers
-- `snakeWith(Position)` and `snakeWith(Direction)` — overloads communicate what the test cares about
-- Test that cares about position: `snakeWith(start)` — direction is irrelevant
-- Test that cares about direction: `snakeWith(direction)` — position is irrelevant
-- `snakeAt()`/`snakeMoving()` were worse names — `snakeWith()` reads naturally
-
-### Randomizing Test Data
-- Hardcoded directions like `Direction.RIGHT` mean the test only proves behavior for that one case
-- `randomDirection()` proves the behavior holds for any direction
-- For `headMovesOneStepInGivenDirection`: use `direction.dx`/`direction.dy` to compute expected position dynamically
-- Only fix a value when the test is specifically about that value (e.g. boundary tests)
+### Randomize Test Data
+- `randomDirection()` proves behavior holds for any direction, not just `Direction.RIGHT`
+- Use `direction.dx`/`direction.dy` to compute expected position dynamically
+- Only fix a value when the test is specifically about that value (e.g. x=0 for wall-collision boundary)
 
 ### Removing Redundant Tests
-- `sizeIncreasesByOneAfterGrow` was redundant — `bodySegmentsAreInCorrectSpatialOrderAfterGrow` already proved size=2 implicitly
+- `sizeIncreasesByOneAfterGrow` was redundant — `bodySegmentsAreInCorrectSpatialOrderAfterGrow` already proved size=2
 - If spatial order is correct, size is correct by definition
 
 ### When NOT to Parameterize
-- CLAUDE.md: parameterize when tests share the same assertion logic and differ only in inputs
-- `eachGrowCallAddsExactlyOneSegment` has two sequential cycles on the same snake instance — cannot parameterize without changing the test's meaning
-- The second grow tests behavior on an already-grown snake, which is distinct from the first
+- `eachGrowCallAddsExactlyOneSegment` runs two sequential cycles on the same instance — parameterizing changes the meaning
+- The second grow tests behavior on an already-grown snake, which is a distinct behavioral property
 
-### Set-Act-Verify Structure
-- Blank lines between phases make the test phases scannable at a glance
-- When grow + move are together in the act phase, they express a single combined action
+## Plan Phase Protocol
 
-## Working With Claude Effectively
+The `eat(Direction)` → `grow(Direction)` → `grow()` redesign cost test rewrites and multiple commits. Entirely preventable in plan mode.
 
-### Catch Design Problems in the Plan Phase
-- The `grow(Direction)` redesign happened mid-implementation — it cost test rewrites, multiple commits, and back-and-forth
-- The root question "does the snake know it ate food?" would have resolved it in seconds during planning
-- **Rule: in the plan phase, for every method, ask Claude: "what does this object know, and does this parameter make sense from its perspective?"**
-- This is cheaper than fixing a test suite
+### The One Question That Catches Most Mistakes
 
-### Challenge the Semantics, Not Just the Structure
-- It's easy to agree on structure (Snake has move, grow, direction) without questioning what each method means
-- `eat(Direction)` passed a structure review — it only failed a semantics review: "the snake doesn't know about food"
-- Push Claude to justify every parameter: "why does grow need a direction?"
+**"Does this object own this value?"** — ask it for every method parameter.
 
-### Name Things From the Object's Perspective
-- If a name leaks another object's concept (food → eat, game over → die), that's a signal the responsibility is wrong
-- Names reveal design problems before code does
+- Snake has no direction state → `grow(Direction)` is wrong → `grow()`
+- Snake has no food knowledge → `eat()` is wrong → `grow()`
 
-### Brainstorm Before Implementing
-- The `grow()` design had three iterations — all the reasoning could have happened in a 5-minute brainstorm
-- Before implementing: ask Claude "show me pros and cons of both approaches" — it surfaces tradeoffs without writing a line of code
+If the object doesn't own the value, the parameter doesn't belong there.
 
-## Workflow
+### In Plan Mode — Before Approving Any Design
 
-### Plan Phase Questions to Ask
-- "What does this object know about the world?" → reveals wrong responsibilities before any code
-- "Does this parameter make sense from this object's perspective?" → catches `grow(Direction)` before implementation
-- Cheaper to fix a concept than a test suite
+1. **One sentence per class** — "This class knows ___ and is responsible for ___" — "and also" = split it
+2. **Signatures only, no bodies** — ask Claude to show method signatures before any implementation
+3. **For every parameter** — "where does this value come from? Does this class own it?"
+4. **Read names from the object's perspective** — a name that borrows another object's concept signals wrong responsibility
+5. **Trace one future change** — "if I change X, which objects need to change?" — wrong objects changing = leaky boundary
 
-### GitHub Issues and Plan Accuracy
-- Issues and plan must reflect current design — stale descriptions mislead future work
-- Close issues only after the PR is merged, not when implementation is complete on the branch
-- Review comments on issues should be deleted when they become inaccurate
-
----
-
-## Pre-Task Design Protocol (Born From Phase 1 Mistakes)
-
-The `eat(Direction)` → `grow(Direction)` → `grow()` journey cost test rewrites, multiple commits, and back-and-forth. All of it could have been resolved in the plan phase. Use this protocol before writing any code for a new class or method.
-
-### Step 1 — Map Responsibility Boundaries
-
-For every class involved in the task, write one sentence:
-> "This class knows: ___ and is responsible for: ___"
-
-If that sentence contains "and also", split the class. This is what would have caught `Snake` storing direction — the sentence becomes "Snake knows its body **and also the last direction the engine chose**", which immediately signals engine concern leaked into Snake.
-
-### Step 2 — Interrogate Every Method Parameter
-
-For each planned method, ask:
-- **"Where does this value come from?"** — the object that owns it is the one that should pass it, not receive it
-- **"Would this method make sense if the object didn't know about X?"** — if yes, X doesn't belong as a parameter
-- **"Can this object compute this itself, or does it require outside knowledge?"** — if outside knowledge, the method is in the wrong place
-
-This is the question that would have killed `grow(Direction)` immediately: the snake has no food or direction state, so why would grow need a direction?
-
-### Step 3 — Name Before You Code
-
-Write the method call in plain English before writing the body:
-- `snake.eat(direction)` → "does the snake know about food?" → no → wrong name, wrong responsibility
-- `snake.grow()` → "is growing a body operation?" → yes → correct
-
-**Rule:** if a method name borrows a concept from another object (food → eat, board → collide, engine → reverse), that's a signal the responsibility is misplaced. Fix the name, and the design follows.
-
-### Step 4 — Ask "What Would Have to Change?"
-
-Pick one likely future requirement and trace the impact:
-> "If we change how food is placed, which objects need to change?"
-
-If the answer includes objects that logically shouldn't care (e.g., Snake changes because food logic changed), the design is leaky. Good boundaries mean each change ripples only within the object that owns that concern.
+Never approve a design without asking: "does this object own every parameter it receives?"
 
 ### Questions to Ask Claude at the Start of Each Task
 
-Before writing any code:
-1. "For each class in this task, what does it know and what is it responsible for — write one sentence per class."
-2. "For each planned method, does every parameter make sense strictly from this object's perspective?"
-3. "Are any of the method names borrowing a concept from another object?"
-4. "If I change [one requirement], which objects would need to change — does that make sense?"
-5. "Show me a minimal skeleton with signatures only — no bodies — and let's validate the design before implementing."
+1. "For each class, one sentence: what it knows and what it's responsible for."
+2. "Show me signatures only — no bodies."
+3. "For each parameter: does this class own this value?"
+4. "Are any names borrowing a concept from another object?"
+5. "If I change [requirement], which objects change — does that make sense?"
 
-Resolving these in the plan phase costs minutes. Resolving them after tests are written costs hours.
+## Workflow
+
+### GitHub Issues and Plan Accuracy
+- Issues and plan must reflect current design — stale descriptions mislead future work
+- Close issues only after the PR is merged
+- Delete review comments when they become inaccurate

--- a/.claude/plans/snake-game-learning-plan.md
+++ b/.claude/plans/snake-game-learning-plan.md
@@ -167,40 +167,40 @@ The iron law: **NO production code without a failing test first.**
 
 ---
 
-#### Task 3 — `Snake`: initialization
-**Behaviour**: A new snake starts at a given position facing a given direction, with a body of exactly one segment.
+#### Task 3 — `Snake`: initialization ✅
+**Behaviour**: A new snake starts at a given position with a body of exactly one segment. The snake has no direction — the caller decides direction at move time.
 **Acceptance criteria**:
-- [ ] Snake starts with one body segment at the given starting position
-- [ ] Snake's head is at the starting position
-- [ ] Snake reports the correct initial direction
-- [ ] Snake's size is 1
+- [x] Snake starts with one body segment at the given starting position
+- [x] Snake's head is at the starting position
 
 ---
 
-#### Task 4 — `Snake`: movement
-**Behaviour**: When the snake moves, its head advances one step in the current direction and its tail is removed. The body length stays the same.
+#### Task 4 — `Snake`: movement ✅
+**Behaviour**: When told to move in a direction, the snake's head advances one step and its tail is removed. The body length stays the same.
 **Acceptance criteria**:
-- [ ] Head is at the new position after moving
-- [ ] Old tail position is no longer part of the body
-- [ ] Size is unchanged after moving
+- [x] Head moves one step in the given direction after move(Direction)
+- [x] Old tail position is no longer part of the body after move(Direction)
+- [x] Size is unchanged after move(Direction)
+- [x] Tail of a multi-segment snake is removed after move(Direction)
 
 ---
 
-#### Task 5 — `Snake`: growth
-**Behaviour**: When the snake grows, its next move retains the tail instead of removing it. Size increases by exactly one.
+#### Task 5 — `Snake`: growth ✅
+**Behaviour**: When told to grow, the snake adds one segment at its tail. The head does not move. The snake has no awareness of food — the engine calls grow() when it determines food was consumed.
 **Acceptance criteria**:
-- [ ] Size increases by 1 after growing and then moving
-- [ ] Body segments are in the correct spatial order after growth
-- [ ] Each grow call adds exactly one segment on the next move
+- [x] grow() does not move the head
+- [x] grow() adds one segment at the tail
+- [x] Each grow() call adds exactly one segment
+- [x] Size is retained after grow() then move()
+- [x] Body is in correct spatial order after grow() then move()
 
 ---
 
-#### Task 6 — `Snake`: direction change
-**Behaviour**: The snake can change direction, but cannot reverse into itself. Invalid direction changes are silently ignored.
+#### Task 6 — `GameEngine`: direction change
+**Behaviour**: Direction change handling lives in the GameEngine. The engine tracks the current direction and rejects reversal attempts before passing a direction to Snake.move(). Originally scoped as a Snake responsibility — moved here because Snake is direction-agnostic.
 **Acceptance criteria**:
-- [ ] Snake adopts the new direction when the change is valid
-- [ ] Snake moving RIGHT ignores a LEFT direction change
-- [ ] Snake moving UP ignores a DOWN direction change
+- [ ] Engine adopts the new direction when the change is valid
+- [ ] Engine ignores a direction change that would reverse into the current direction
 - [ ] Direction is unchanged after an ignored input
 
 ---

--- a/.claude/plans/snake-game-learning-plan.md
+++ b/.claude/plans/snake-game-learning-plan.md
@@ -1,0 +1,788 @@
+# Snake Game with Spring Boot, WebFlux & AI Agents - Learning Plan
+
+## Project Philosophy
+**Control**: You drive architecture decisions and understand every line of code
+**Learning**: Each phase builds on solid understanding from previous phases
+**Incremental**: Start simple, add complexity gradually
+**Best Practices**: Learn to work effectively with Claude Code throughout
+
+---
+
+## Phase 1: Foundation - Basic Snake Game (Plain Java)
+**Goal**: Understand core game logic before adding frameworks — and establish the right habits for working with Claude throughout this project.
+
+### Main Goals
+**Technical**: Build a working Snake game in plain Java with full understanding of every line.
+
+**Meta — Learning to work with Claude the right way**:
+- Always ask Claude to explain a concept *before* any code is written
+- You propose the design; Claude advises and implements based on your decisions
+- Question every pattern: "Why did you use X here instead of Y?"
+- Never accept code you can't explain — slow down and ask
+- Use Claude as a tutor and pair programmer, not a code generator
+
+### Learning Objectives
+**Java & OOP:**
+- Game loop and state management
+- Collision detection algorithms
+- Object-oriented design (single responsibility, encapsulation)
+- Java collections: why `ArrayDeque` beats `LinkedList` for this use case
+
+**Working with Claude:**
+- How to ask for explanations before implementation
+- How to drive architecture decisions yourself
+- How to review generated code critically
+- How to use `/commit` after each completed, tested feature
+- Recognising when you're moving too fast (can't explain what you just built)
+
+### Architecture Decisions (DECIDED)
+| Decision | Choice | Reason |
+|----------|--------|--------|
+| Snake body | `ArrayDeque<Position>` | No extra Node wrapper objects per element — LinkedList allocates a Node + Position per segment, ArrayDeque only allocates the Position |
+| Coordinate system | Top-left (0,0), Y increases downward | Matches HTML Canvas directly — no coordinate translation needed in Phase 3 |
+| Direction reversal | Blocked | Cannot reverse into yourself — illegal move is silently ignored |
+
+### Build Order
+Build in dependency order — each class only depends on classes already written.
+
+1. **`Position`** — x, y coordinates. No dependencies.
+2. **`Direction`** — enum: UP, DOWN, LEFT, RIGHT. No dependencies.
+3. **`Snake`** — body as `ArrayDeque<Position>`, current direction. Depends on `Position`, `Direction`.
+4. **`Food`** — a position on the board. Depends on `Position`.
+5. **`GameBoard`** — width, height, holds snake and food. Depends on `Position`, `Snake`, `Food`.
+6. **`CollisionDetector`** — wall and self collision. Depends on `Position`, `Snake`, `GameBoard`.
+7. **`GameEngine`** — game loop, movement, food placement, collision checks. Depends on everything above.
+8. **`Main`** — entry point, wires everything together.
+
+### Files to Create
+```
+src/main/java/com/snake/
+├── model/
+│   ├── Position.java           (x, y coordinates)
+│   ├── Direction.java          (enum: UP, DOWN, LEFT, RIGHT)
+│   ├── Snake.java              (body as ArrayDeque<Position>, direction)
+│   ├── Food.java               (food position)
+│   └── GameBoard.java          (board dimensions, snake, food)
+├── engine/
+│   ├── GameEngine.java         (game loop, movement, scoring)
+│   └── CollisionDetector.java  (wall & self collision)
+└── Main.java                   (entry point)
+```
+*Test files are defined per-task below — the subagent creates them following TDD.*
+
+### Execution Strategy
+**Skill**: `superpowers:subagent-driven-development`
+
+Claude dispatches a fresh subagent per task → spec compliance review → code quality review → auto-fix → commit. Only escalates to you when genuinely blocked.
+
+**You review at class boundaries, not between every task:**
+
+| Review checkpoint | Tasks covered |
+|-------------------|--------------|
+| Review 1 | Task 0–2: setup, Position, Direction |
+| Review 2 | Task 3–6: Snake (all behaviours) |
+| Review 3 | Task 7–8: Food, GameBoard |
+| Review 4 | Task 9–10: CollisionDetector |
+| Review 5 | Task 11–14: GameEngine, Main |
+
+**Stop conditions — Claude escalates to you when:**
+- A task is BLOCKED (missing dependency, test won't compile)
+- Acceptance criteria are ambiguous (two valid interpretations)
+- A design decision requires your input (e.g. edge case not covered in plan)
+- Any task fails spec compliance review after 2 fix attempts
+
+**Continue autonomously when:**
+- Tests pass (`mvn test` exits 0)
+- Spec compliance reviewer approves
+- Code quality reviewer approves
+
+**Code quality reviewer must check against:**
+- All rules in `~/.claude/CLAUDE.md` — no wildcards, no nulls, no ternary, no comments, specific exceptions, always final, Hamcrest assertions
+- TDD anti-patterns (see superpowers testing-anti-patterns reference)
+- General Java best practices
+
+**At each review checkpoint, you check:**
+1. Does the design match what was approved in the plan?
+2. Any CLAUDE.md rule violations the reviewer missed?
+3. Any security concerns (input validation, data exposure)?
+4. Do tests verify real behaviour — not just size, not just null?
+5. Can you explain every architectural decision without looking at the plan?
+
+*For this learning project*: also read every line at each checkpoint — understanding generated code is part of the learning goal.
+
+### TDD Workflow — What the Subagent Does Per Task
+**Skill**: `superpowers:test-driven-development` — every implementer subagent follows this.
+
+The iron law: **NO production code without a failing test first.**
+
+1. Subagent reads the task's acceptance criteria (behaviour only — no method signatures)
+2. Subagent **invents the API** by imagining the ideal caller interface, writes the test
+3. Subagent runs `mvn test` → confirms it **fails for the right reason (Red)**
+4. Subagent writes the **minimum code** to pass — nothing more
+5. Subagent runs `mvn test` → **all green**
+6. Subagent refactors if needed, keeps tests green
+7. Subagent commits and reports back to orchestrator
+
+**What YOU do at each review checkpoint:**
+- Read every line of committed code
+- Verify it matches what you approved in the plan
+- Ask questions about anything unexpected
+- Check CLAUDE.md rule compliance
+- Only proceed to next group of tasks when you can explain everything
+
+**Red flags — subagent stops and escalates:**
+- Test passed immediately (testing existing behaviour, not new)
+- Cannot determine the right API from acceptance criteria alone
+- Code written before test (restart the task)
+
+### Phase 1 Tasks
+
+#### Task 0 — Project Setup
+**Goal**: Compile and run a test before writing any game code.
+**Test first**: A single dummy test that asserts `true` — just to prove the test runner works.
+**Acceptance criteria**:
+- [x] `pom.xml` exists with JUnit 5 + Hamcrest dependencies
+- [x] Maven directory structure in place (`src/main/java`, `src/test/java`)
+- [x] `mvn test` runs and passes
+
+---
+
+#### Task 1 — `Position`: value object
+**Behaviour**: Represents a coordinate on the board. Two positions at the same location are equal.
+**Acceptance criteria**:
+- [x] Stores an x and a y coordinate
+- [x] Two positions with the same x and y are considered equal
+- [x] Two positions with different coordinates are not equal
+- [x] Equality is symmetric and consistent (a.equals(b) == b.equals(a))
+
+---
+
+#### Task 2 — `Direction`: movement enum
+**Behaviour**: Represents the four directions a snake can move. Each direction knows how it changes position. A direction knows its opposite.
+**Acceptance criteria**:
+- [x] Four directions exist: UP, DOWN, LEFT, RIGHT
+- [x] Each direction produces a predictable position change (e.g. UP moves y by -1, DOWN by +1)
+- [x] UP and DOWN are opposites; LEFT and RIGHT are opposites
+- [x] No direction is its own opposite
+
+---
+
+#### Task 3 — `Snake`: initialization
+**Behaviour**: A new snake starts at a given position facing a given direction, with a body of exactly one segment.
+**Acceptance criteria**:
+- [ ] Snake starts with one body segment at the given starting position
+- [ ] Snake's head is at the starting position
+- [ ] Snake reports the correct initial direction
+- [ ] Snake's size is 1
+
+---
+
+#### Task 4 — `Snake`: movement
+**Behaviour**: When the snake moves, its head advances one step in the current direction and its tail is removed. The body length stays the same.
+**Acceptance criteria**:
+- [ ] Head is at the new position after moving
+- [ ] Old tail position is no longer part of the body
+- [ ] Size is unchanged after moving
+
+---
+
+#### Task 5 — `Snake`: growth
+**Behaviour**: When the snake grows, its next move retains the tail instead of removing it. Size increases by exactly one.
+**Acceptance criteria**:
+- [ ] Size increases by 1 after growing and then moving
+- [ ] Body segments are in the correct spatial order after growth
+- [ ] Each grow call adds exactly one segment on the next move
+
+---
+
+#### Task 6 — `Snake`: direction change
+**Behaviour**: The snake can change direction, but cannot reverse into itself. Invalid direction changes are silently ignored.
+**Acceptance criteria**:
+- [ ] Snake adopts the new direction when the change is valid
+- [ ] Snake moving RIGHT ignores a LEFT direction change
+- [ ] Snake moving UP ignores a DOWN direction change
+- [ ] Direction is unchanged after an ignored input
+
+---
+
+#### Task 7 — `Food`: value object
+**Behaviour**: Represents a piece of food at a position on the board. Two food items at the same position are equal.
+**Acceptance criteria**:
+- [ ] Food has a position on the board
+- [ ] Two food items at the same position are equal
+- [ ] Position is accessible after creation
+
+---
+
+#### Task 8 — `GameBoard`: dimensions and bounds
+**Behaviour**: Represents the playable area. Knows its size and whether any given position falls within the boundaries.
+**Acceptance criteria**:
+- [ ] Board has a width and height
+- [ ] A position inside the board is within bounds
+- [ ] A position at x=0, y=0 (top-left) is within bounds
+- [ ] A position at x=width or y=height (on or beyond edge) is out of bounds
+- [ ] All four edges are correctly treated as out of bounds
+
+---
+
+#### Task 9 — `CollisionDetector`: wall collision
+**Behaviour**: Detects when a position falls outside the board boundaries.
+**Acceptance criteria**:
+- [ ] Position beyond the left edge is a wall collision
+- [ ] Position beyond the right edge is a wall collision
+- [ ] Position beyond the top edge is a wall collision
+- [ ] Position beyond the bottom edge is a wall collision
+- [ ] Valid position inside the board is not a wall collision
+
+---
+
+#### Task 10 — `CollisionDetector`: self collision
+**Behaviour**: Detects when the snake's head occupies the same position as any part of its own body.
+**Acceptance criteria**:
+- [ ] Head overlapping a body segment is a self collision
+- [ ] Head not overlapping any body segment is not a self collision
+- [ ] Test uses a snake with enough segments that self collision is geometrically possible
+
+---
+
+#### Task 11 — `GameEngine`: single tick — movement
+**Behaviour**: One game tick advances the snake one step in its current direction.
+**Acceptance criteria**:
+- [ ] Snake's head is one step further in its direction after a tick
+- [ ] Snake's size is unchanged if no food was eaten
+
+---
+
+#### Task 12 — `GameEngine`: food eaten
+**Behaviour**: When the snake's head reaches the food, the snake grows, a new food is placed on an empty cell, and the score increases.
+**Acceptance criteria**:
+- [ ] Snake is one segment longer after eating food
+- [ ] New food does not appear on any cell the snake occupies
+- [ ] Score increases by 1 each time food is eaten
+
+---
+
+#### Task 13 — `GameEngine`: game over
+**Behaviour**: The game ends when the snake hits a wall or itself. Once over, ticks have no effect.
+**Acceptance criteria**:
+- [ ] Game is over after a wall collision
+- [ ] Game is over after a self collision
+- [ ] Ticking a finished game changes nothing
+- [ ] Score is preserved and accessible after game over
+
+---
+
+#### Task 14 — `Main`: console runner
+**Goal**: Wire everything together and prove the game runs end-to-end.
+**No test**: This is integration glue — manually verify it runs.
+**Acceptance criteria**:
+- [ ] Game starts with a snake in the centre of a 20×20 board
+- [ ] Prints board state to console each tick
+- [ ] Runs until collision then prints final score
+
+### Acceptance Criteria
+
+**Technical — the game works:**
+- [ ] Snake moves in all four directions
+- [ ] Snake grows by one segment when it eats food
+- [ ] Game ends on wall collision
+- [ ] Game ends on self collision
+- [ ] Direction reversal is blocked (ignored silently)
+- [ ] New food spawns in a random empty cell after eating
+- [ ] Score increments on each food eaten
+- [ ] All unit tests pass with meaningful assertions (no null-only or size-only checks)
+
+**Understanding — you own the code:**
+- [ ] You can explain what `ArrayDeque` is and why it was chosen
+- [ ] You can trace a full game tick through the code (move → check collision → check food → update state)
+- [ ] You can explain how wall collision is detected
+- [ ] You can explain how self collision is detected
+- [ ] You can add a new method to any class without Claude's help
+
+**Process — right habits established:**
+- [ ] Each class was designed (fields/methods discussed) before being implemented
+- [ ] You asked at least one "why" question per class
+- [ ] Each class was committed separately after its tests passed
+- [ ] You never accepted code you couldn't explain
+
+### Red Flags — Slow Down If:
+- You can't explain what a class does after it's written
+- A test is failing and you don't know why
+- You're reading the code for the first time after it's already committed
+- You're copy-pasting without understanding
+
+---
+
+## Phase 2: Spring Boot Integration
+**Goal**: Transform plain Java game into Spring Boot application
+
+### Learning Objectives
+- Spring Boot project structure
+- Dependency injection and IoC container
+- Spring component model (@Service, @Component)
+- Configuration management (@ConfigurationProperties)
+- Spring Boot testing
+
+### What You'll Build
+- Spring Boot application structure
+- Game configuration (board size, speed, etc.)
+- Service layer for game management
+- RESTful API for game control (start, pause, reset)
+- Basic HTML page to display game state
+
+### New Concepts to Learn
+- **Dependency Injection**: GameEngine receives dependencies via constructor
+- **Application Properties**: External configuration (application.yml)
+- **REST Controllers**: Exposing game operations via HTTP
+- **Spring Boot Auto-configuration**: Understanding what happens at startup
+
+### Files to Create/Modify
+```
+pom.xml                         (Spring Boot dependencies)
+src/main/resources/
+├── application.yml             (configuration)
+└── static/
+    └── index.html              (basic UI)
+
+src/main/java/com/snake/
+├── SnakeGameApplication.java   (Spring Boot entry point)
+├── config/
+│   └── GameConfig.java         (@ConfigurationProperties)
+├── service/
+│   └── GameService.java        (@Service - wraps GameEngine)
+└── controller/
+    └── GameController.java     (REST endpoints)
+
+src/test/java/com/snake/
+├── service/
+│   └── GameServiceTest.java    (unit tests)
+└── controller/
+    └── GameControllerTest.java (integration tests with @SpringBootTest)
+```
+
+### Architecture Decisions (YOU decide)
+- Which classes become Spring beans vs POJOs?
+- What configuration goes in application.yml vs code?
+- Should GameEngine be singleton or prototype scope?
+- REST API design (endpoints, request/response format)
+
+### Claude's Role in Phase 2
+- **Explain**: Spring Boot concepts before implementing
+- **Guide**: Show Spring Boot patterns and best practices
+- **Implement**: Based on YOUR architectural decisions
+- **Review**: Ensure you understand dependency injection flow
+
+### Verification Steps
+1. Spring Boot application starts successfully
+2. Can call REST API to start/pause/reset game
+3. Configuration changes in application.yml work correctly
+4. All tests pass (unit + integration)
+5. You can explain the Spring bean lifecycle
+
+### Exit Criteria
+- Working Spring Boot application
+- Understanding of dependency injection
+- Comfortable with Spring testing patterns
+- Can modify configuration without breaking the app
+
+---
+
+## Phase 3: Reactive Programming with WebFlux & WebSocket
+**Goal**: Add real-time multiplayer using reactive streams
+
+### Learning Objectives
+- Reactive programming concepts (Flux, Mono)
+- WebSocket for bidirectional communication
+- Managing concurrent game state
+- Server-Sent Events (SSE) vs WebSocket trade-offs
+- Backpressure handling
+
+### What You'll Build
+- WebSocket endpoint for real-time game updates
+- Multiple concurrent game sessions
+- Browser-based UI with HTML5 Canvas
+- Real-time game state broadcasting
+- Player input handling via WebSocket
+
+### New Concepts to Learn
+- **Flux**: Stream of game state updates
+- **Mono**: Single async operations (start game, move)
+- **WebSocket**: Bidirectional real-time communication
+- **Reactive Streams**: Publisher-Subscriber model
+- **Schedulers**: Controlling game loop execution
+
+### Files to Create/Modify
+```
+pom.xml                         (add spring-boot-starter-webflux)
+
+src/main/java/com/snake/
+├── websocket/
+│   ├── GameWebSocketHandler.java    (WebSocket handler)
+│   └── GameSessionManager.java      (manages multiple games)
+├── service/
+│   └── ReactiveGameService.java     (reactive game operations)
+└── config/
+    └── WebSocketConfig.java         (WebSocket configuration)
+
+src/main/resources/static/
+├── game.html                   (Canvas-based UI)
+├── js/
+│   ├── game-client.js          (WebSocket client)
+│   └── renderer.js             (Canvas rendering)
+└── css/
+    └── game.css                (styling)
+
+src/test/java/com/snake/
+├── websocket/
+│   └── GameWebSocketHandlerTest.java
+└── service/
+    └── ReactiveGameServiceTest.java
+```
+
+### Architecture Decisions (YOU decide)
+- WebSocket message format (JSON structure)
+- How to identify different game sessions?
+- Flux vs observable for game state updates?
+- How to handle player disconnections?
+- Client-side prediction vs server authoritative?
+
+### Claude's Role in Phase 3
+- **Teach**: Explain reactive programming before coding
+- **Clarify**: Answer questions about Flux/Mono operations
+- **Show**: Demonstrate WebSocket patterns
+- **Verify**: Ensure you understand backpressure concepts
+
+### Verification Steps
+1. Multiple browsers can connect simultaneously
+2. Each browser sees its game state in real-time
+3. Player input (arrow keys) controls snake via WebSocket
+4. Game state updates at consistent frame rate
+5. No memory leaks with long-running sessions
+6. You can explain the Flux pipeline for game updates
+
+### Exit Criteria
+- Multiplayer working with real-time updates
+- Solid understanding of reactive streams
+- Can modify WebSocket message format
+- Comfortable debugging async issues
+
+---
+
+## Phase 4: AI Opponents - Strategy Patterns
+**Goal**: Add AI snakes with different personalities
+
+### Learning Objectives
+- Pathfinding algorithms (A*, BFS)
+- Strategy pattern implementation
+- AI decision-making systems
+- Performance optimization for AI calculations
+- Testing non-deterministic behavior
+
+### What You'll Build
+- Multiple AI strategies (Aggressive, Defensive, Random)
+- Pathfinding service using A* algorithm
+- AI decision engine that selects moves
+- Game mode: 1 human vs 3 AI snakes
+- AI difficulty levels
+
+### AI Strategies to Implement
+1. **Random**: Moves randomly (baseline)
+2. **Greedy**: Always moves toward nearest food
+3. **Smart**: Uses A* pathfinding, avoids collisions
+4. **Aggressive**: Tries to trap other snakes
+5. **Defensive**: Prioritizes survival over food
+
+### Files to Create
+```
+src/main/java/com/snake/
+├── ai/
+│   ├── AiStrategy.java              (interface)
+│   ├── RandomStrategy.java
+│   ├── GreedyStrategy.java
+│   ├── SmartStrategy.java
+│   ├── AggressiveStrategy.java
+│   └── DefensiveStrategy.java
+├── pathfinding/
+│   ├── PathFinder.java              (interface)
+│   ├── AStarPathFinder.java
+│   └── BreadthFirstPathFinder.java
+├── service/
+│   └── AiDecisionService.java       (selects AI moves)
+└── model/
+    └── AiSnake.java                 (extends Snake)
+
+src/test/java/com/snake/
+├── ai/
+│   └── StrategyTests.java
+└── pathfinding/
+    └── AStarPathFinderTest.java
+```
+
+### Architecture Decisions (YOU decide)
+- How often should AI recalculate path?
+- Should AI have perfect information or limited visibility?
+- How to balance AI performance vs game responsiveness?
+- Strategy selection at game start or dynamic?
+- How to make AI "feel" different to players?
+
+### Claude's Role in Phase 4
+- **Explain**: A* algorithm before implementing
+- **Guide**: Show strategy pattern best practices
+- **Collaborate**: Implement each strategy together
+- **Challenge**: Ask you to predict AI behavior
+- **Optimize**: Help profile and improve performance
+
+### Verification Steps
+1. Each AI strategy behaves distinctly
+2. Smart AI can navigate to food without dying
+3. Aggressive AI actively pursues other snakes
+4. Performance test: 10 AI snakes run smoothly
+5. You can explain how A* works
+6. You can add a new strategy independently
+
+### Exit Criteria
+- 5 working AI strategies with distinct personalities
+- Understanding of pathfinding algorithms
+- Can tune AI difficulty
+- Comfortable with strategy pattern
+
+---
+
+## Phase 5: Reinforcement Learning Agents (Advanced)
+**Goal**: Add AI that learns and improves over time
+
+### Learning Objectives
+- Reinforcement learning basics (Q-learning, Deep Q-Networks)
+- State representation for ML
+- Reward function design
+- Training vs inference modes
+- Integration with existing game engine
+
+### What You'll Build
+- RL agent using DL4J or TensorFlow Java
+- Training mode to let AI learn
+- Trained model persistence and loading
+- Performance comparison vs rule-based AI
+- Metrics dashboard (win rate, avg score)
+
+### New Concepts to Learn
+- **State Representation**: How to encode game state for neural network
+- **Reward Function**: Points for food, penalties for death
+- **Exploration vs Exploitation**: Epsilon-greedy strategy
+- **Neural Network Architecture**: Input layer, hidden layers, output
+- **Training Process**: Episodes, batches, convergence
+
+### Files to Create
+```
+pom.xml                         (add DL4J or TensorFlow)
+
+src/main/java/com/snake/
+├── ml/
+│   ├── RLAgent.java                 (reinforcement learning agent)
+│   ├── StateEncoder.java            (converts game state to input)
+│   ├── RewardCalculator.java        (reward function)
+│   ├── NeuralNetworkModel.java      (NN definition)
+│   └── TrainingService.java         (training loop)
+├── service/
+│   └── MLGameService.java           (training mode manager)
+└── controller/
+    └── TrainingController.java      (training control API)
+
+src/main/resources/
+└── models/
+    └── trained-snake-model.zip      (saved model)
+
+src/test/java/com/snake/
+└── ml/
+    └── RLAgentTest.java
+```
+
+### Architecture Decisions (YOU decide)
+- Which RL algorithm to use? (Q-learning vs DQN vs PPO)
+- State representation format? (grid, coordinates, features)
+- Reward function parameters?
+- Network architecture (layers, neurons)?
+- When to stop training (convergence criteria)?
+
+### Claude's Role in Phase 5
+- **Educate**: Explain RL concepts step-by-step
+- **Research**: Help compare ML libraries for Java
+- **Design**: Collaborate on state encoding
+- **Debug**: Help troubleshoot training issues
+- **Analyze**: Interpret training metrics together
+
+### Verification Steps
+1. RL agent can be trained in headless mode
+2. Training progress visible (loss decreasing)
+3. Trained agent performs better than random
+4. Model can be saved and reloaded
+5. Inference works in multiplayer game
+6. You understand the reward function impact
+7. You can modify network architecture
+
+### Exit Criteria
+- Working RL agent that learns to play
+- Understanding of RL fundamentals
+- Can experiment with hyperparameters
+- Agent competes reasonably with rule-based AI
+
+---
+
+## Best Practices: Working with Claude Throughout
+
+### For Each Feature
+1. **Ask for explanation first**: "Explain [concept] before we implement"
+2. **Review architecture together**: "What are the trade-offs of approach A vs B?"
+3. **Understand each file**: "Walk me through what this class does"
+4. **Question patterns**: "Why did you use Optional here instead of null?"
+5. **Test understanding**: Try to modify code yourself before asking Claude
+
+### Using Claude Code Effectively
+
+**High-Control Interactions** (You lead):
+```
+You: "I want to add a new AI strategy that avoids the center.
+      Let's design it together first."
+Claude: [Explains approach, you discuss]
+You: "Ok, let's implement it with that approach"
+Claude: [Implements YOUR design]
+```
+
+**Collaborative Learning**:
+```
+You: "Show me 3 different ways to handle WebSocket disconnections"
+Claude: [Presents options with pros/cons]
+You: "I'll go with option 2. Explain why that's better for our use case"
+Claude: [Explains reasoning]
+```
+
+**Agent Autonomy** (Later phases):
+```
+You: "Refactor all AI strategies to use the new pathfinding interface"
+Claude: [Uses Task agent to handle multi-file refactor]
+You: [Review changes, understand the pattern]
+```
+
+### When to Use Skills
+- `/commit`: After each completed feature
+- `/review-pr`: Before finalizing a phase
+- `/learn-from-mr`: If you have MR comments to incorporate
+
+### Signs You're Moving Too Fast
+- You can't explain what a class does
+- Tests are failing and you don't know why
+- You're accepting code without understanding it
+- You're confused about Spring Boot magic
+
+**Solution**: Slow down, ask Claude to explain, or simplify the feature.
+
+---
+
+## Critical Files Overview
+
+### Phase 1 (Plain Java)
+- `Snake.java` - Core game entity
+- `GameEngine.java` - Game loop and rules
+- `CollisionDetector.java` - Collision logic
+
+### Phase 2 (Spring Boot)
+- `pom.xml` - Dependencies and build config
+- `SnakeGameApplication.java` - Entry point
+- `GameService.java` - Spring-managed game logic
+- `application.yml` - Configuration
+
+### Phase 3 (WebFlux)
+- `GameWebSocketHandler.java` - WebSocket logic
+- `ReactiveGameService.java` - Reactive game operations
+- `game-client.js` - Frontend WebSocket client
+
+### Phase 4 (AI)
+- `AiStrategy.java` - Strategy interface
+- `AStarPathFinder.java` - Pathfinding implementation
+- Individual strategy implementations
+
+### Phase 5 (ML)
+- `RLAgent.java` - Reinforcement learning agent
+- `StateEncoder.java` - Game state to ML input
+- `NeuralNetworkModel.java` - Neural network definition
+
+---
+
+## Progressive Complexity Model
+
+```
+Phase 1: Plain Java
+├─ Complexity: Low
+├─ Concepts: 3-5
+└─ Control: 100% You
+
+Phase 2: Spring Boot
+├─ Complexity: Medium
+├─ Concepts: 5-8
+└─ Control: 80% You, 20% Claude
+
+Phase 3: WebFlux
+├─ Complexity: Medium-High
+├─ Concepts: 8-12
+└─ Control: 70% You, 30% Claude
+
+Phase 4: AI Strategies
+├─ Complexity: High
+├─ Concepts: 10-15
+└─ Control: 60% You, 40% Claude
+
+Phase 5: ML/RL
+├─ Complexity: Very High
+├─ Concepts: 15-20
+└─ Control: 50% You, 50% Claude (collaborative)
+```
+
+---
+
+## Success Metrics Per Phase
+
+### You know you're ready to move to next phase when:
+1. ✅ All tests pass
+2. ✅ You can explain every class's purpose
+3. ✅ You can modify code independently
+4. ✅ You understand the key concepts
+5. ✅ You're excited (not overwhelmed) about next phase
+
+### Red Flags to Slow Down:
+1. ❌ Copying code without understanding
+2. ❌ Tests failing without knowing why
+3. ❌ Can't explain architectural decisions
+4. ❌ Feeling lost in Spring Boot "magic"
+5. ❌ Accepting suggestions blindly
+
+---
+
+## Recommended Timeline
+
+**Not time-based, milestone-based**:
+- Phase 1: Until you fully understand game mechanics
+- Phase 2: Until Spring Boot patterns click
+- Phase 3: Until reactive programming makes sense
+- Phase 4: Until you can design AI strategies yourself
+- Phase 5: Until you grasp RL fundamentals
+
+**Trust your understanding, not the clock.**
+
+---
+
+## Final Notes
+
+This is YOUR learning project. Claude is:
+- ✅ Your tutor (explains concepts)
+- ✅ Your pair programmer (implements together)
+- ✅ Your code reviewer (catches mistakes)
+- ✅ Your research assistant (finds best practices)
+
+Claude is NOT:
+- ❌ A magic code generator
+- ❌ A replacement for your understanding
+- ❌ Responsible for your learning pace
+
+**The goal is not to finish fast. The goal is to deeply understand Spring Boot, WebFlux, and AI agents through a fun project.**
+
+Take your time. Ask questions. Experiment. Break things. Learn.

--- a/src/main/java/com/snake/model/Snake.java
+++ b/src/main/java/com/snake/model/Snake.java
@@ -17,7 +17,7 @@ public class Snake {
         body.removeLast();
     }
 
-    public void eat(final Direction direction) {
+    public void grow(final Direction direction) {
         body.addFirst(nextHead(direction));
     }
 

--- a/src/main/java/com/snake/model/Snake.java
+++ b/src/main/java/com/snake/model/Snake.java
@@ -1,0 +1,56 @@
+package com.snake.model;
+
+import java.util.ArrayDeque;
+
+public class Snake {
+
+    private final ArrayDeque<Position> body;
+    private Direction direction;
+    private int pendingGrowth;
+
+    public Snake(final Position start, final Direction direction) {
+        this.body = new ArrayDeque<>();
+        this.body.addFirst(start);
+        this.direction = direction;
+        this.pendingGrowth = 0;
+    }
+
+    public void move() {
+        final var newHead = new Position(
+            body.getFirst().x() + direction.dx,
+            body.getFirst().y() + direction.dy
+        );
+        body.addFirst(newHead);
+        if (pendingGrowth > 0) {
+            pendingGrowth--;
+        } else {
+            body.removeLast();
+        }
+    }
+
+    public void grow() {
+        pendingGrowth++;
+    }
+
+    public void changeDirection(final Direction newDirection) {
+        if (!newDirection.equals(direction.opposite())) {
+            direction = newDirection;
+        }
+    }
+
+    public Position head() {
+        return body.getFirst();
+    }
+
+    public ArrayDeque<Position> body() {
+        return body;
+    }
+
+    public Direction direction() {
+        return direction;
+    }
+
+    public int size() {
+        return body.size();
+    }
+}

--- a/src/main/java/com/snake/model/Snake.java
+++ b/src/main/java/com/snake/model/Snake.java
@@ -5,40 +5,26 @@ import java.util.ArrayDeque;
 public class Snake {
 
     private final ArrayDeque<Position> body;
-    private Direction direction;
-    private int segmentsToAdd;
 
-    public Snake(final Position start, final Direction direction) {
+    public Snake(final Position start) {
         this.body = new ArrayDeque<>();
         this.body.addFirst(start);
-        this.direction = direction;
-        this.segmentsToAdd = 0;
     }
 
-    public void move() {
-        body.addFirst(nextHead());
-        if (segmentsToAdd > 0) {
-            segmentsToAdd--;
-        } else {
-            body.removeLast();
-        }
+    public void move(final Direction direction) {
+        body.addFirst(nextHead(direction));
+        body.removeLast();
     }
 
-    public void grow() {
-        segmentsToAdd++;
+    public void eat(final Direction direction) {
+        body.addFirst(nextHead(direction));
     }
 
-    private Position nextHead() {
+    private Position nextHead(final Direction direction) {
         return new Position(
             body.getFirst().x() + direction.dx,
             body.getFirst().y() + direction.dy
         );
-    }
-
-    public void changeDirection(final Direction newDirection) {
-        if (!newDirection.equals(direction.opposite())) {
-            direction = newDirection;
-        }
     }
 
     public Position head() {
@@ -47,10 +33,6 @@ public class Snake {
 
     public ArrayDeque<Position> body() {
         return body;
-    }
-
-    public Direction direction() {
-        return direction;
     }
 
     public int size() {

--- a/src/main/java/com/snake/model/Snake.java
+++ b/src/main/java/com/snake/model/Snake.java
@@ -17,8 +17,8 @@ public class Snake {
         body.removeLast();
     }
 
-    public void grow(final Direction direction) {
-        body.addFirst(nextHead(direction));
+    public void grow() {
+        body.addLast(body.getLast());
     }
 
     private Position nextHead(final Direction direction) {

--- a/src/main/java/com/snake/model/Snake.java
+++ b/src/main/java/com/snake/model/Snake.java
@@ -1,6 +1,7 @@
 package com.snake.model;
 
 import java.util.ArrayDeque;
+import java.util.Deque;
 
 public class Snake {
 
@@ -31,7 +32,7 @@ public class Snake {
         return body.getFirst();
     }
 
-    public ArrayDeque<Position> body() {
+    public Deque<Position> body() {
         return body;
     }
 

--- a/src/main/java/com/snake/model/Snake.java
+++ b/src/main/java/com/snake/model/Snake.java
@@ -6,30 +6,33 @@ public class Snake {
 
     private final ArrayDeque<Position> body;
     private Direction direction;
-    private int pendingGrowth;
+    private int segmentsToAdd;
 
     public Snake(final Position start, final Direction direction) {
         this.body = new ArrayDeque<>();
         this.body.addFirst(start);
         this.direction = direction;
-        this.pendingGrowth = 0;
+        this.segmentsToAdd = 0;
     }
 
     public void move() {
-        final var newHead = new Position(
-            body.getFirst().x() + direction.dx,
-            body.getFirst().y() + direction.dy
-        );
-        body.addFirst(newHead);
-        if (pendingGrowth > 0) {
-            pendingGrowth--;
+        body.addFirst(nextHead());
+        if (segmentsToAdd > 0) {
+            segmentsToAdd--;
         } else {
             body.removeLast();
         }
     }
 
     public void grow() {
-        pendingGrowth++;
+        segmentsToAdd++;
+    }
+
+    private Position nextHead() {
+        return new Position(
+            body.getFirst().x() + direction.dx,
+            body.getFirst().y() + direction.dy
+        );
     }
 
     public void changeDirection(final Direction newDirection) {

--- a/src/main/java/com/snake/model/Snake.java
+++ b/src/main/java/com/snake/model/Snake.java
@@ -5,7 +5,7 @@ import java.util.Deque;
 
 public class Snake {
 
-    private final ArrayDeque<Position> body;
+    private final Deque<Position> body;
 
     public Snake(final Position start) {
         this.body = new ArrayDeque<>();

--- a/src/test/java/com/snake/model/SnakeTest.java
+++ b/src/test/java/com/snake/model/SnakeTest.java
@@ -3,8 +3,7 @@ package com.snake.model;
 import static com.snake.model.TestData.randomDirection;
 import static com.snake.model.TestData.randomPosition;
 import static com.snake.model.TestData.randomSnake;
-import static com.snake.model.TestData.snakeAt;
-import static com.snake.model.TestData.snakeMoving;
+import static com.snake.model.TestData.snakeWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
@@ -21,7 +20,7 @@ class SnakeTest {
     @DisplayName("head is at the starting position")
     void headIsAtStartingPosition() {
         final var start = randomPosition();
-        final var snake = snakeAt(start);
+        final var snake = snakeWith(start);
         assertThat(snake.head(), equalTo(start));
     }
 
@@ -29,14 +28,14 @@ class SnakeTest {
     @DisplayName("starts with one body segment at the starting position")
     void startsWithOneBodySegmentAtStartingPosition() {
         final var start = randomPosition();
-        final var snake = snakeAt(start);
+        final var snake = snakeWith(start);
         assertThat(snake.body(), contains(start));
     }
 
     @Test
     @DisplayName("reports the correct initial direction")
     void reportsCorrectInitialDirection() {
-        final var snake = snakeMoving(Direction.UP);
+        final var snake = snakeWith(Direction.UP);
         assertThat(snake.direction(), equalTo(Direction.UP));
     }
 
@@ -44,16 +43,17 @@ class SnakeTest {
     @DisplayName("head moves one step in current direction after move")
     void headMovesOneStepInCurrentDirection() {
         final var start = randomPosition();
-        final var snake = new Snake(start, Direction.RIGHT);
+        final var direction = randomDirection();
+        final var snake = new Snake(start, direction);
         snake.move();
-        assertThat(snake.head(), equalTo(new Position(start.x() + 1, start.y())));
+        assertThat(snake.head(), equalTo(new Position(start.x() + direction.dx, start.y() + direction.dy)));
     }
 
     @Test
     @DisplayName("old tail is removed after move")
     void oldTailIsRemovedAfterMove() {
         final var start = randomPosition();
-        final var snake = snakeAt(start);
+        final var snake = snakeWith(start);
         snake.move();
         assertThat(snake.body(), not(hasItem(start)));
     }
@@ -91,17 +91,18 @@ class SnakeTest {
     @DisplayName("body segments are in correct spatial order after growth")
     void bodySegmentsAreInCorrectSpatialOrderAfterGrowth() {
         final var start = randomPosition();
-        final var snake = new Snake(start, Direction.RIGHT);
+        final var direction = randomDirection();
+        final var snake = new Snake(start, direction);
         snake.grow();
         snake.move();
-        assertThat(snake.head(), equalTo(new Position(start.x() + 1, start.y())));
+        assertThat(snake.head(), equalTo(new Position(start.x() + direction.dx, start.y() + direction.dy)));
         assertThat(snake.body().getLast(), equalTo(start));
     }
 
     @Test
     @DisplayName("adopts new direction when change is valid")
     void adoptsNewDirectionWhenValid() {
-        final var snake = snakeMoving(Direction.RIGHT);
+        final var snake = snakeWith(Direction.RIGHT);
         snake.changeDirection(Direction.UP);
         assertThat(snake.direction(), equalTo(Direction.UP));
     }
@@ -109,7 +110,7 @@ class SnakeTest {
     @Test
     @DisplayName("ignores direction change that would reverse into itself")
     void ignoresReversalDirectionChange() {
-        final var snake = snakeMoving(Direction.RIGHT);
+        final var snake = snakeWith(Direction.RIGHT);
         snake.changeDirection(Direction.LEFT);
         assertThat(snake.direction(), equalTo(Direction.RIGHT));
     }
@@ -117,7 +118,7 @@ class SnakeTest {
     @Test
     @DisplayName("direction is unchanged after an ignored input")
     void directionUnchangedAfterIgnoredInput() {
-        final var snake = snakeMoving(Direction.UP);
+        final var snake = snakeWith(Direction.UP);
         snake.changeDirection(Direction.DOWN);
         assertThat(snake.direction(), equalTo(Direction.UP));
     }

--- a/src/test/java/com/snake/model/SnakeTest.java
+++ b/src/test/java/com/snake/model/SnakeTest.java
@@ -59,30 +59,30 @@ class SnakeTest {
     }
 
     @Test
-    @DisplayName("size increases by 1 after eat")
-    void sizeIncreasesByOneAfterEat() {
+    @DisplayName("size increases by 1 after grow")
+    void sizeIncreasesByOneAfterGrow() {
         final var snake = randomSnake();
-        snake.eat(randomDirection());
+        snake.grow(randomDirection());
         assertThat(snake.size(), equalTo(2));
     }
 
     @Test
-    @DisplayName("each eat call adds exactly one segment")
-    void eachEatCallAddsExactlyOneSegment() {
+    @DisplayName("each grow call adds exactly one segment")
+    void eachGrowCallAddsExactlyOneSegment() {
         final var snake = randomSnake();
-        snake.eat(randomDirection());
+        snake.grow(randomDirection());
         assertThat(snake.size(), equalTo(2));
-        snake.eat(randomDirection());
+        snake.grow(randomDirection());
         assertThat(snake.size(), equalTo(3));
     }
 
     @Test
-    @DisplayName("body segments are in correct spatial order after eat")
-    void bodySegmentsAreInCorrectSpatialOrderAfterEat() {
+    @DisplayName("body segments are in correct spatial order after grow")
+    void bodySegmentsAreInCorrectSpatialOrderAfterGrow() {
         final var start = randomPosition();
         final var direction = randomDirection();
         final var snake = snakeWith(start);
-        snake.eat(direction);
+        snake.grow(direction);
         assertThat(snake.head(), equalTo(positionAfterStep(start, direction)));
         assertThat(snake.body().getLast(), equalTo(start));
     }

--- a/src/test/java/com/snake/model/SnakeTest.java
+++ b/src/test/java/com/snake/model/SnakeTest.java
@@ -59,14 +59,6 @@ class SnakeTest {
     }
 
     @Test
-    @DisplayName("size increases by 1 after grow")
-    void sizeIncreasesByOneAfterGrow() {
-        final var snake = randomSnake();
-        snake.grow(randomDirection());
-        assertThat(snake.size(), equalTo(2));
-    }
-
-    @Test
     @DisplayName("each grow call adds exactly one segment")
     void eachGrowCallAddsExactlyOneSegment() {
         final var snake = randomSnake();

--- a/src/test/java/com/snake/model/SnakeTest.java
+++ b/src/test/java/com/snake/model/SnakeTest.java
@@ -71,6 +71,29 @@ class SnakeTest {
     }
 
     @Test
+    @DisplayName("tail of a multi-segment snake is removed after move")
+    void tailOfMultiSegmentSnakeIsRemovedAfterMove() {
+        final var start = randomPosition();
+        final var snake = snakeWith(start);
+        snake.grow(randomDirection());
+
+        snake.move(randomDirection());
+
+        assertThat(snake.body(), not(hasItem(start)));
+    }
+
+    @Test
+    @DisplayName("size is retained after grow then move")
+    void sizeIsRetainedAfterGrowThenMove() {
+        final var snake = randomSnake();
+        snake.grow(randomDirection());
+
+        snake.move(randomDirection());
+
+        assertThat(snake.size(), equalTo(2));
+    }
+
+    @Test
     @DisplayName("each grow call adds exactly one segment")
     void eachGrowCallAddsExactlyOneSegment() {
         final var snake = randomSnake();

--- a/src/test/java/com/snake/model/SnakeTest.java
+++ b/src/test/java/com/snake/model/SnakeTest.java
@@ -13,13 +13,6 @@ import org.junit.jupiter.api.Test;
 class SnakeTest {
 
     @Test
-    @DisplayName("starts with size 1")
-    void startsWithSizeOne() {
-        final var snake = new Snake(randomPosition(), Direction.RIGHT);
-        assertThat(snake.size(), equalTo(1));
-    }
-
-    @Test
     @DisplayName("head is at the starting position")
     void headIsAtStartingPosition() {
         final var start = randomPosition();

--- a/src/test/java/com/snake/model/SnakeTest.java
+++ b/src/test/java/com/snake/model/SnakeTest.java
@@ -1,5 +1,6 @@
 package com.snake.model;
 
+import static com.snake.model.TestData.positionAfterStep;
 import static com.snake.model.TestData.randomDirection;
 import static com.snake.model.TestData.randomPosition;
 import static com.snake.model.TestData.randomSnake;
@@ -48,7 +49,7 @@ class SnakeTest {
         final var direction = randomDirection();
         final var snake = new Snake(start, direction);
         snake.move();
-        assertThat(snake.head(), equalTo(new Position(start.x() + direction.dx, start.y() + direction.dy)));
+        assertThat(snake.head(), equalTo(positionAfterStep(start, direction)));
     }
 
     @Test
@@ -97,7 +98,7 @@ class SnakeTest {
         final var snake = new Snake(start, direction);
         snake.grow();
         snake.move();
-        assertThat(snake.head(), equalTo(new Position(start.x() + direction.dx, start.y() + direction.dy)));
+        assertThat(snake.head(), equalTo(positionAfterStep(start, direction)));
         assertThat(snake.body().getLast(), equalTo(start));
     }
 

--- a/src/test/java/com/snake/model/SnakeTest.java
+++ b/src/test/java/com/snake/model/SnakeTest.java
@@ -1,0 +1,118 @@
+package com.snake.model;
+
+import static com.snake.model.TestData.randomPosition;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Snake")
+class SnakeTest {
+
+    @Test
+    @DisplayName("starts with size 1")
+    void startsWithSizeOne() {
+        final var snake = new Snake(randomPosition(), Direction.RIGHT);
+        assertThat(snake.size(), equalTo(1));
+    }
+
+    @Test
+    @DisplayName("head is at the starting position")
+    void headIsAtStartingPosition() {
+        final var start = randomPosition();
+        final var snake = new Snake(start, Direction.RIGHT);
+        assertThat(snake.head(), equalTo(start));
+    }
+
+    @Test
+    @DisplayName("reports the correct initial direction")
+    void reportsCorrectInitialDirection() {
+        final var snake = new Snake(randomPosition(), Direction.UP);
+        assertThat(snake.direction(), equalTo(Direction.UP));
+    }
+
+    @Test
+    @DisplayName("head moves one step in current direction after move")
+    void headMovesOneStepInCurrentDirection() {
+        final var start = randomPosition();
+        final var snake = new Snake(start, Direction.RIGHT);
+        snake.move();
+        assertThat(snake.head(), equalTo(new Position(start.x() + 1, start.y())));
+    }
+
+    @Test
+    @DisplayName("old tail is removed after move")
+    void oldTailIsRemovedAfterMove() {
+        final var start = randomPosition();
+        final var snake = new Snake(start, Direction.RIGHT);
+        snake.move();
+        assertThat(snake.body(), not(hasItem(start)));
+    }
+
+    @Test
+    @DisplayName("size is unchanged after move")
+    void sizeIsUnchangedAfterMove() {
+        final var snake = new Snake(randomPosition(), Direction.DOWN);
+        snake.move();
+        assertThat(snake.size(), equalTo(1));
+    }
+
+    @Test
+    @DisplayName("size increases by 1 after grow then move")
+    void sizeIncreasesByOneAfterGrowThenMove() {
+        final var snake = new Snake(randomPosition(), Direction.RIGHT);
+        snake.grow();
+        snake.move();
+        assertThat(snake.size(), equalTo(2));
+    }
+
+    @Test
+    @DisplayName("each grow call adds exactly one segment on the next move")
+    void eachGrowCallAddsExactlyOneSegment() {
+        final var snake = new Snake(randomPosition(), Direction.RIGHT);
+        snake.grow();
+        snake.grow();
+        snake.move();
+        assertThat(snake.size(), equalTo(2));
+        snake.move();
+        assertThat(snake.size(), equalTo(3));
+    }
+
+    @Test
+    @DisplayName("body segments are in correct spatial order after growth")
+    void bodySegmentsAreInCorrectSpatialOrderAfterGrowth() {
+        final var start = randomPosition();
+        final var snake = new Snake(start, Direction.RIGHT);
+        snake.grow();
+        snake.move();
+        assertThat(snake.head(), equalTo(new Position(start.x() + 1, start.y())));
+        assertThat(snake.body().getLast(), equalTo(start));
+    }
+
+    @Test
+    @DisplayName("adopts new direction when change is valid")
+    void adoptsNewDirectionWhenValid() {
+        final var snake = new Snake(randomPosition(), Direction.RIGHT);
+        snake.changeDirection(Direction.UP);
+        assertThat(snake.direction(), equalTo(Direction.UP));
+    }
+
+    @Test
+    @DisplayName("ignores direction change that would reverse into itself")
+    void ignoresReversalDirectionChange() {
+        final var snake = new Snake(randomPosition(), Direction.RIGHT);
+        snake.changeDirection(Direction.LEFT);
+        assertThat(snake.direction(), equalTo(Direction.RIGHT));
+    }
+
+    @Test
+    @DisplayName("direction is unchanged after an ignored input")
+    void directionUnchangedAfterIgnoredInput() {
+        final var snake = new Snake(randomPosition(), Direction.UP);
+        snake.changeDirection(Direction.DOWN);
+        assertThat(snake.direction(), equalTo(Direction.UP));
+    }
+}

--- a/src/test/java/com/snake/model/SnakeTest.java
+++ b/src/test/java/com/snake/model/SnakeTest.java
@@ -21,14 +21,20 @@ class SnakeTest {
     @DisplayName("head is at the starting position")
     void headIsAtStartingPosition() {
         final var start = randomPosition();
-        assertThat(snakeWith(start).head(), equalTo(start));
+
+        final var snake = snakeWith(start);
+
+        assertThat(snake.head(), equalTo(start));
     }
 
     @Test
     @DisplayName("starts with one body segment at the starting position")
     void startsWithOneBodySegmentAtStartingPosition() {
         final var start = randomPosition();
-        assertThat(snakeWith(start).body(), contains(start));
+
+        final var snake = snakeWith(start);
+
+        assertThat(snake.body(), contains(start));
     }
 
     @Test
@@ -37,7 +43,9 @@ class SnakeTest {
         final var start = randomPosition();
         final var direction = randomDirection();
         final var snake = snakeWith(start);
+
         snake.move(direction);
+
         assertThat(snake.head(), equalTo(positionAfterStep(start, direction)));
     }
 
@@ -46,7 +54,9 @@ class SnakeTest {
     void oldTailIsRemovedAfterMove() {
         final var start = randomPosition();
         final var snake = snakeWith(start);
+
         snake.move(randomDirection());
+
         assertThat(snake.body(), not(hasItem(start)));
     }
 
@@ -54,7 +64,9 @@ class SnakeTest {
     @DisplayName("size is unchanged after move")
     void sizeIsUnchangedAfterMove() {
         final var snake = randomSnake();
+
         snake.move(randomDirection());
+
         assertThat(snake.size(), equalTo(1));
     }
 
@@ -62,8 +74,10 @@ class SnakeTest {
     @DisplayName("each grow call adds exactly one segment")
     void eachGrowCallAddsExactlyOneSegment() {
         final var snake = randomSnake();
+
         snake.grow(randomDirection());
         assertThat(snake.size(), equalTo(2));
+
         snake.grow(randomDirection());
         assertThat(snake.size(), equalTo(3));
     }
@@ -74,7 +88,9 @@ class SnakeTest {
         final var start = randomPosition();
         final var direction = randomDirection();
         final var snake = snakeWith(start);
+
         snake.grow(direction);
+
         assertThat(snake.head(), equalTo(positionAfterStep(start, direction)));
         assertThat(snake.body().getLast(), equalTo(start));
     }

--- a/src/test/java/com/snake/model/SnakeTest.java
+++ b/src/test/java/com/snake/model/SnakeTest.java
@@ -71,26 +71,25 @@ class SnakeTest {
     }
 
     @Test
-    @DisplayName("tail of a multi-segment snake is removed after move")
-    void tailOfMultiSegmentSnakeIsRemovedAfterMove() {
+    @DisplayName("grow does not move the head")
+    void growDoesNotMoveHead() {
         final var start = randomPosition();
         final var snake = snakeWith(start);
-        snake.grow(randomDirection());
 
-        snake.move(randomDirection());
+        snake.grow();
 
-        assertThat(snake.body(), not(hasItem(start)));
+        assertThat(snake.head(), equalTo(start));
     }
 
     @Test
-    @DisplayName("size is retained after grow then move")
-    void sizeIsRetainedAfterGrowThenMove() {
-        final var snake = randomSnake();
-        snake.grow(randomDirection());
+    @DisplayName("grow adds one segment at the tail")
+    void growAddsOneSegmentAtTail() {
+        final var start = randomPosition();
+        final var snake = snakeWith(start);
 
-        snake.move(randomDirection());
+        snake.grow();
 
-        assertThat(snake.size(), equalTo(2));
+        assertThat(snake.body(), contains(start, start));
     }
 
     @Test
@@ -98,21 +97,33 @@ class SnakeTest {
     void eachGrowCallAddsExactlyOneSegment() {
         final var snake = randomSnake();
 
-        snake.grow(randomDirection());
+        snake.grow();
         assertThat(snake.size(), equalTo(2));
 
-        snake.grow(randomDirection());
+        snake.grow();
         assertThat(snake.size(), equalTo(3));
     }
 
     @Test
-    @DisplayName("body segments are in correct spatial order after grow")
-    void bodySegmentsAreInCorrectSpatialOrderAfterGrow() {
+    @DisplayName("size is retained after grow then move")
+    void sizeIsRetainedAfterGrowThenMove() {
+        final var snake = randomSnake();
+        snake.grow();
+
+        snake.move(randomDirection());
+
+        assertThat(snake.size(), equalTo(2));
+    }
+
+    @Test
+    @DisplayName("body is in correct spatial order after grow then move")
+    void bodyIsInCorrectSpatialOrderAfterGrowThenMove() {
         final var start = randomPosition();
         final var direction = randomDirection();
         final var snake = snakeWith(start);
+        snake.grow();
 
-        snake.grow(direction);
+        snake.move(direction);
 
         assertThat(snake.head(), equalTo(positionAfterStep(start, direction)));
         assertThat(snake.body().getLast(), equalTo(start));

--- a/src/test/java/com/snake/model/SnakeTest.java
+++ b/src/test/java/com/snake/model/SnakeTest.java
@@ -47,7 +47,7 @@ class SnakeTest {
     void headMovesOneStepInCurrentDirection() {
         final var start = randomPosition();
         final var direction = randomDirection();
-        final var snake = new Snake(start, direction);
+        final var snake = snakeWith(start, direction);
         snake.move();
         assertThat(snake.head(), equalTo(positionAfterStep(start, direction)));
     }
@@ -95,7 +95,7 @@ class SnakeTest {
     void bodySegmentsAreInCorrectSpatialOrderAfterGrowth() {
         final var start = randomPosition();
         final var direction = randomDirection();
-        final var snake = new Snake(start, direction);
+        final var snake = snakeWith(start, direction);
         snake.grow();
         snake.move();
         assertThat(snake.head(), equalTo(positionAfterStep(start, direction)));

--- a/src/test/java/com/snake/model/SnakeTest.java
+++ b/src/test/java/com/snake/model/SnakeTest.java
@@ -2,6 +2,7 @@ package com.snake.model;
 
 import static com.snake.model.TestData.randomPosition;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
@@ -18,6 +19,14 @@ class SnakeTest {
         final var start = randomPosition();
         final var snake = new Snake(start, Direction.RIGHT);
         assertThat(snake.head(), equalTo(start));
+    }
+
+    @Test
+    @DisplayName("starts with one body segment at the starting position")
+    void startsWithOneBodySegmentAtStartingPosition() {
+        final var start = randomPosition();
+        final var snake = new Snake(start, Direction.RIGHT);
+        assertThat(snake.body(), contains(start));
     }
 
     @Test

--- a/src/test/java/com/snake/model/SnakeTest.java
+++ b/src/test/java/com/snake/model/SnakeTest.java
@@ -105,11 +105,11 @@ class SnakeTest {
     }
 
     @Test
-    @DisplayName("size is retained after grow then move")
+    @DisplayName("size is retained after grows then move")
     void sizeIsRetainedAfterGrowThenMove() {
         final var snake = randomSnake();
-        snake.grow();
 
+        snake.grow();
         snake.move(randomDirection());
 
         assertThat(snake.size(), equalTo(2));

--- a/src/test/java/com/snake/model/SnakeTest.java
+++ b/src/test/java/com/snake/model/SnakeTest.java
@@ -4,7 +4,6 @@ import static com.snake.model.TestData.positionAfterStep;
 import static com.snake.model.TestData.randomDirection;
 import static com.snake.model.TestData.randomPosition;
 import static com.snake.model.TestData.randomSnake;
-import static com.snake.model.TestData.randomValidChangeFrom;
 import static com.snake.model.TestData.snakeWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
@@ -22,33 +21,23 @@ class SnakeTest {
     @DisplayName("head is at the starting position")
     void headIsAtStartingPosition() {
         final var start = randomPosition();
-        final var snake = snakeWith(start);
-        assertThat(snake.head(), equalTo(start));
+        assertThat(snakeWith(start).head(), equalTo(start));
     }
 
     @Test
     @DisplayName("starts with one body segment at the starting position")
     void startsWithOneBodySegmentAtStartingPosition() {
         final var start = randomPosition();
-        final var snake = snakeWith(start);
-        assertThat(snake.body(), contains(start));
+        assertThat(snakeWith(start).body(), contains(start));
     }
 
     @Test
-    @DisplayName("reports the correct initial direction")
-    void reportsCorrectInitialDirection() {
-        final var direction = randomDirection();
-        final var snake = snakeWith(direction);
-        assertThat(snake.direction(), equalTo(direction));
-    }
-
-    @Test
-    @DisplayName("head moves one step in current direction after move")
-    void headMovesOneStepInCurrentDirection() {
+    @DisplayName("head moves one step in the given direction after move")
+    void headMovesOneStepInGivenDirection() {
         final var start = randomPosition();
         final var direction = randomDirection();
-        final var snake = snakeWith(start, direction);
-        snake.move();
+        final var snake = snakeWith(start);
+        snake.move(direction);
         assertThat(snake.head(), equalTo(positionAfterStep(start, direction)));
     }
 
@@ -57,7 +46,7 @@ class SnakeTest {
     void oldTailIsRemovedAfterMove() {
         final var start = randomPosition();
         final var snake = snakeWith(start);
-        snake.move();
+        snake.move(randomDirection());
         assertThat(snake.body(), not(hasItem(start)));
     }
 
@@ -65,68 +54,36 @@ class SnakeTest {
     @DisplayName("size is unchanged after move")
     void sizeIsUnchangedAfterMove() {
         final var snake = randomSnake();
-        snake.move();
+        snake.move(randomDirection());
         assertThat(snake.size(), equalTo(1));
     }
 
     @Test
-    @DisplayName("size increases by 1 after grow then move")
-    void sizeIncreasesByOneAfterGrowThenMove() {
+    @DisplayName("size increases by 1 after eat")
+    void sizeIncreasesByOneAfterEat() {
         final var snake = randomSnake();
-        snake.grow();
-        snake.move();
+        snake.eat(randomDirection());
         assertThat(snake.size(), equalTo(2));
     }
 
     @Test
-    @DisplayName("each grow call adds exactly one segment on the next move")
-    void eachGrowCallAddsExactlyOneSegment() {
+    @DisplayName("each eat call adds exactly one segment")
+    void eachEatCallAddsExactlyOneSegment() {
         final var snake = randomSnake();
-        snake.grow();
-        snake.grow();
-        snake.move();
+        snake.eat(randomDirection());
         assertThat(snake.size(), equalTo(2));
-        snake.move();
+        snake.eat(randomDirection());
         assertThat(snake.size(), equalTo(3));
     }
 
     @Test
-    @DisplayName("body segments are in correct spatial order after growth")
-    void bodySegmentsAreInCorrectSpatialOrderAfterGrowth() {
+    @DisplayName("body segments are in correct spatial order after eat")
+    void bodySegmentsAreInCorrectSpatialOrderAfterEat() {
         final var start = randomPosition();
         final var direction = randomDirection();
-        final var snake = snakeWith(start, direction);
-        snake.grow();
-        snake.move();
+        final var snake = snakeWith(start);
+        snake.eat(direction);
         assertThat(snake.head(), equalTo(positionAfterStep(start, direction)));
         assertThat(snake.body().getLast(), equalTo(start));
-    }
-
-    @Test
-    @DisplayName("adopts new direction when change is valid")
-    void adoptsNewDirectionWhenValid() {
-        final var direction = randomDirection();
-        final var snake = snakeWith(direction);
-        final var validChange = randomValidChangeFrom(direction);
-        snake.changeDirection(validChange);
-        assertThat(snake.direction(), equalTo(validChange));
-    }
-
-    @Test
-    @DisplayName("ignores direction change that would reverse into itself")
-    void ignoresReversalDirectionChange() {
-        final var direction = randomDirection();
-        final var snake = snakeWith(direction);
-        snake.changeDirection(direction.opposite());
-        assertThat(snake.direction(), equalTo(direction));
-    }
-
-    @Test
-    @DisplayName("direction is unchanged after an ignored input")
-    void directionUnchangedAfterIgnoredInput() {
-        final var direction = randomDirection();
-        final var snake = snakeWith(direction);
-        snake.changeDirection(direction.opposite());
-        assertThat(snake.direction(), equalTo(direction));
     }
 }

--- a/src/test/java/com/snake/model/SnakeTest.java
+++ b/src/test/java/com/snake/model/SnakeTest.java
@@ -121,8 +121,8 @@ class SnakeTest {
         final var start = randomPosition();
         final var direction = randomDirection();
         final var snake = snakeWith(start);
-        snake.grow();
 
+        snake.grow();
         snake.move(direction);
 
         assertThat(snake.head(), equalTo(positionAfterStep(start, direction)));

--- a/src/test/java/com/snake/model/SnakeTest.java
+++ b/src/test/java/com/snake/model/SnakeTest.java
@@ -1,6 +1,10 @@
 package com.snake.model;
 
+import static com.snake.model.TestData.randomDirection;
 import static com.snake.model.TestData.randomPosition;
+import static com.snake.model.TestData.randomSnake;
+import static com.snake.model.TestData.snakeAt;
+import static com.snake.model.TestData.snakeMoving;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
@@ -17,7 +21,7 @@ class SnakeTest {
     @DisplayName("head is at the starting position")
     void headIsAtStartingPosition() {
         final var start = randomPosition();
-        final var snake = new Snake(start, Direction.RIGHT);
+        final var snake = snakeAt(start);
         assertThat(snake.head(), equalTo(start));
     }
 
@@ -25,14 +29,14 @@ class SnakeTest {
     @DisplayName("starts with one body segment at the starting position")
     void startsWithOneBodySegmentAtStartingPosition() {
         final var start = randomPosition();
-        final var snake = new Snake(start, Direction.RIGHT);
+        final var snake = snakeAt(start);
         assertThat(snake.body(), contains(start));
     }
 
     @Test
     @DisplayName("reports the correct initial direction")
     void reportsCorrectInitialDirection() {
-        final var snake = new Snake(randomPosition(), Direction.UP);
+        final var snake = snakeMoving(Direction.UP);
         assertThat(snake.direction(), equalTo(Direction.UP));
     }
 
@@ -49,7 +53,7 @@ class SnakeTest {
     @DisplayName("old tail is removed after move")
     void oldTailIsRemovedAfterMove() {
         final var start = randomPosition();
-        final var snake = new Snake(start, Direction.RIGHT);
+        final var snake = snakeAt(start);
         snake.move();
         assertThat(snake.body(), not(hasItem(start)));
     }
@@ -57,7 +61,7 @@ class SnakeTest {
     @Test
     @DisplayName("size is unchanged after move")
     void sizeIsUnchangedAfterMove() {
-        final var snake = new Snake(randomPosition(), Direction.DOWN);
+        final var snake = randomSnake();
         snake.move();
         assertThat(snake.size(), equalTo(1));
     }
@@ -65,7 +69,7 @@ class SnakeTest {
     @Test
     @DisplayName("size increases by 1 after grow then move")
     void sizeIncreasesByOneAfterGrowThenMove() {
-        final var snake = new Snake(randomPosition(), Direction.RIGHT);
+        final var snake = randomSnake();
         snake.grow();
         snake.move();
         assertThat(snake.size(), equalTo(2));
@@ -74,7 +78,7 @@ class SnakeTest {
     @Test
     @DisplayName("each grow call adds exactly one segment on the next move")
     void eachGrowCallAddsExactlyOneSegment() {
-        final var snake = new Snake(randomPosition(), Direction.RIGHT);
+        final var snake = randomSnake();
         snake.grow();
         snake.grow();
         snake.move();
@@ -97,7 +101,7 @@ class SnakeTest {
     @Test
     @DisplayName("adopts new direction when change is valid")
     void adoptsNewDirectionWhenValid() {
-        final var snake = new Snake(randomPosition(), Direction.RIGHT);
+        final var snake = snakeMoving(Direction.RIGHT);
         snake.changeDirection(Direction.UP);
         assertThat(snake.direction(), equalTo(Direction.UP));
     }
@@ -105,7 +109,7 @@ class SnakeTest {
     @Test
     @DisplayName("ignores direction change that would reverse into itself")
     void ignoresReversalDirectionChange() {
-        final var snake = new Snake(randomPosition(), Direction.RIGHT);
+        final var snake = snakeMoving(Direction.RIGHT);
         snake.changeDirection(Direction.LEFT);
         assertThat(snake.direction(), equalTo(Direction.RIGHT));
     }
@@ -113,7 +117,7 @@ class SnakeTest {
     @Test
     @DisplayName("direction is unchanged after an ignored input")
     void directionUnchangedAfterIgnoredInput() {
-        final var snake = new Snake(randomPosition(), Direction.UP);
+        final var snake = snakeMoving(Direction.UP);
         snake.changeDirection(Direction.DOWN);
         assertThat(snake.direction(), equalTo(Direction.UP));
     }

--- a/src/test/java/com/snake/model/SnakeTest.java
+++ b/src/test/java/com/snake/model/SnakeTest.java
@@ -3,6 +3,7 @@ package com.snake.model;
 import static com.snake.model.TestData.randomDirection;
 import static com.snake.model.TestData.randomPosition;
 import static com.snake.model.TestData.randomSnake;
+import static com.snake.model.TestData.randomValidChangeFrom;
 import static com.snake.model.TestData.snakeWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
@@ -35,8 +36,9 @@ class SnakeTest {
     @Test
     @DisplayName("reports the correct initial direction")
     void reportsCorrectInitialDirection() {
-        final var snake = snakeWith(Direction.UP);
-        assertThat(snake.direction(), equalTo(Direction.UP));
+        final var direction = randomDirection();
+        final var snake = snakeWith(direction);
+        assertThat(snake.direction(), equalTo(direction));
     }
 
     @Test
@@ -102,24 +104,28 @@ class SnakeTest {
     @Test
     @DisplayName("adopts new direction when change is valid")
     void adoptsNewDirectionWhenValid() {
-        final var snake = snakeWith(Direction.RIGHT);
-        snake.changeDirection(Direction.UP);
-        assertThat(snake.direction(), equalTo(Direction.UP));
+        final var direction = randomDirection();
+        final var snake = snakeWith(direction);
+        final var validChange = randomValidChangeFrom(direction);
+        snake.changeDirection(validChange);
+        assertThat(snake.direction(), equalTo(validChange));
     }
 
     @Test
     @DisplayName("ignores direction change that would reverse into itself")
     void ignoresReversalDirectionChange() {
-        final var snake = snakeWith(Direction.RIGHT);
-        snake.changeDirection(Direction.LEFT);
-        assertThat(snake.direction(), equalTo(Direction.RIGHT));
+        final var direction = randomDirection();
+        final var snake = snakeWith(direction);
+        snake.changeDirection(direction.opposite());
+        assertThat(snake.direction(), equalTo(direction));
     }
 
     @Test
     @DisplayName("direction is unchanged after an ignored input")
     void directionUnchangedAfterIgnoredInput() {
-        final var snake = snakeWith(Direction.UP);
-        snake.changeDirection(Direction.DOWN);
-        assertThat(snake.direction(), equalTo(Direction.UP));
+        final var direction = randomDirection();
+        final var snake = snakeWith(direction);
+        snake.changeDirection(direction.opposite());
+        assertThat(snake.direction(), equalTo(direction));
     }
 }

--- a/src/test/java/com/snake/model/TestData.java
+++ b/src/test/java/com/snake/model/TestData.java
@@ -1,6 +1,5 @@
 package com.snake.model;
 
-import java.util.Arrays;
 import java.util.concurrent.ThreadLocalRandom;
 
 final class TestData {

--- a/src/test/java/com/snake/model/TestData.java
+++ b/src/test/java/com/snake/model/TestData.java
@@ -1,5 +1,6 @@
 package com.snake.model;
 
+import java.util.Arrays;
 import java.util.concurrent.ThreadLocalRandom;
 
 final class TestData {
@@ -29,5 +30,12 @@ final class TestData {
 
     static Snake snakeWith(final Direction direction) {
         return new Snake(randomPosition(), direction);
+    }
+
+    static Direction randomValidChangeFrom(final Direction current) {
+        final var valid = Arrays.stream(Direction.values())
+            .filter(d -> !d.equals(current) && !d.equals(current.opposite()))
+            .toList();
+        return valid.get(ThreadLocalRandom.current().nextInt(valid.size()));
     }
 }

--- a/src/test/java/com/snake/model/TestData.java
+++ b/src/test/java/com/snake/model/TestData.java
@@ -13,4 +13,21 @@ final class TestData {
     static Position randomPosition() {
         return new Position(randomCoordinate(), randomCoordinate());
     }
+
+    static Direction randomDirection() {
+        final var values = Direction.values();
+        return values[ThreadLocalRandom.current().nextInt(values.length)];
+    }
+
+    static Snake randomSnake() {
+        return new Snake(randomPosition(), randomDirection());
+    }
+
+    static Snake snakeAt(final Position start) {
+        return new Snake(start, randomDirection());
+    }
+
+    static Snake snakeMoving(final Direction direction) {
+        return new Snake(randomPosition(), direction);
+    }
 }

--- a/src/test/java/com/snake/model/TestData.java
+++ b/src/test/java/com/snake/model/TestData.java
@@ -23,11 +23,11 @@ final class TestData {
         return new Snake(randomPosition(), randomDirection());
     }
 
-    static Snake snakeAt(final Position start) {
+    static Snake snakeWith(final Position start) {
         return new Snake(start, randomDirection());
     }
 
-    static Snake snakeMoving(final Direction direction) {
+    static Snake snakeWith(final Direction direction) {
         return new Snake(randomPosition(), direction);
     }
 }

--- a/src/test/java/com/snake/model/TestData.java
+++ b/src/test/java/com/snake/model/TestData.java
@@ -21,29 +21,14 @@ final class TestData {
     }
 
     static Snake randomSnake() {
-        return new Snake(randomPosition(), randomDirection());
+        return new Snake(randomPosition());
     }
 
     static Snake snakeWith(final Position start) {
-        return new Snake(start, randomDirection());
-    }
-
-    static Snake snakeWith(final Direction direction) {
-        return new Snake(randomPosition(), direction);
-    }
-
-    static Snake snakeWith(final Position start, final Direction direction) {
-        return new Snake(start, direction);
+        return new Snake(start);
     }
 
     static Position positionAfterStep(final Position from, final Direction direction) {
         return new Position(from.x() + direction.dx, from.y() + direction.dy);
-    }
-
-    static Direction randomValidChangeFrom(final Direction current) {
-        final var valid = Arrays.stream(Direction.values())
-            .filter(d -> !d.equals(current) && !d.equals(current.opposite()))
-            .toList();
-        return valid.get(ThreadLocalRandom.current().nextInt(valid.size()));
     }
 }

--- a/src/test/java/com/snake/model/TestData.java
+++ b/src/test/java/com/snake/model/TestData.java
@@ -32,6 +32,10 @@ final class TestData {
         return new Snake(randomPosition(), direction);
     }
 
+    static Position positionAfterStep(final Position from, final Direction direction) {
+        return new Position(from.x() + direction.dx, from.y() + direction.dy);
+    }
+
     static Direction randomValidChangeFrom(final Direction current) {
         final var valid = Arrays.stream(Direction.values())
             .filter(d -> !d.equals(current) && !d.equals(current.opposite()))

--- a/src/test/java/com/snake/model/TestData.java
+++ b/src/test/java/com/snake/model/TestData.java
@@ -32,6 +32,10 @@ final class TestData {
         return new Snake(randomPosition(), direction);
     }
 
+    static Snake snakeWith(final Position start, final Direction direction) {
+        return new Snake(start, direction);
+    }
+
     static Position positionAfterStep(final Position from, final Direction direction) {
         return new Position(from.x() + direction.dx, from.y() + direction.dy);
     }


### PR DESCRIPTION
## Summary
- Adds `.claude/CLAUDE.md` — project-level rule to always pull from main before starting work
- Extends `.claude/learnings.md` with a **Pre-Task Design Protocol** distilled from Phase 1 tasks 1-5

## Context
The `eat(Direction)` → `grow(Direction)` → `grow()` redesign during Phase 1 caused test rewrites, multiple commits, and back-and-forth that could have been resolved in the plan phase. The new protocol documents the root cause and gives a concrete 4-step process + 5 questions to ask before any future implementation.

## What's in the protocol
1. **Map responsibility boundaries** — one sentence per class; "and also" = split it
2. **Interrogate every parameter** — does the object actually own this value?
3. **Name before you code** — names that borrow another object's concept reveal misplaced responsibility
4. **What would have to change?** — trace one future requirement to validate clean boundaries

## Test plan
- [ ] Review `.claude/learnings.md` — confirm the protocol accurately captures the Phase 1 lessons
- [ ] Review `.claude/CLAUDE.md` — confirm the git-pull rule is correct